### PR TITLE
REST client utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "axios": "^0.18.0",
+    "js-cookie": "^2.2.0",
     "vue": "^2.5.16"
   },
   "devDependencies": {
@@ -32,7 +34,10 @@
       "plugin:vue/essential",
       "@vue/airbnb"
     ],
-    "rules": {},
+    "rules": {
+      "no-underscore-dangle": 0,
+      "import/prefer-default-export": 0
+    },
     "parserOptions": {
       "parser": "babel-eslint"
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,10 +6,14 @@
 </template>
 
 <script>
+import RestClient from './rest';
 import HelloWorld from './components/HelloWorld.vue';
 
 export default {
   name: 'app',
+  provide: {
+    girderRest: new RestClient(),
+  },
   components: {
     HelloWorld,
   },

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import cookies from 'js-cookie';
+
+export default class RestClient {
+  constructor(apiRoot = '/api/v1', { useCookie = true }) {
+    this._axios = axios.create();
+    this._axios.defaults.baseURL = apiRoot;
+
+    if (useCookie) {
+      this.token = cookies.get('girderToken');
+    }
+  }
+
+  /**
+   * Register a callback function that will be called on error responses.
+   * @param {Function} fn The function to be called. The callback will receive
+   *     a single argument, an axios error object. If you wish to ignore the
+   *     error, return a value. If you wish to propagate the error, return
+   *     a rejected Promise with the original argument.
+   */
+  onErrorResponse(fn) {
+    this._axios.interceptors.response.use(undefined, fn);
+  }
+
+  /**
+   * Use this to make Web API requests.
+   * @returns An Object with the same API as axios.
+   */
+  get request() {
+    return this._axios;
+  }
+
+  get token() {
+    return this._token;
+  }
+
+  set token(val) {
+    this._token = val;
+    if (val) {
+      this._axios.defaults.headers.common['Girder-Token'] = val;
+    } else {
+      delete this._axios.default.headers.common['Girder-Token'];
+    }
+  }
+}

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,34 +1,23 @@
-import axios from 'axios';
+import axios_ from 'axios';
 import cookies from 'js-cookie';
 
+/**
+ * This is a subclass of axios that is meant to add Girder-specific helper functionality.
+ */
 export default class RestClient {
-  constructor(apiRoot = '/api/v1', { useCookie = true }) {
-    this._axios = axios.create();
-    this._axios.defaults.baseURL = apiRoot;
+  constructor({ apiRoot = '/api/v1', token = cookies.get('girderToken'), axios = axios_.create() } = {}) {
+    Object.assign(this, axios, {
+      apiRoot,
+      token,
+    });
 
-    if (useCookie) {
-      this.token = cookies.get('girderToken');
-    }
-  }
-
-  /**
-   * Use this to make Web API requests.
-   * @returns An Object with the same API as axios.
-   */
-  get request() {
-    return this._axios;
-  }
-
-  get token() {
-    return this._token;
-  }
-
-  set token(val) {
-    this._token = val;
-    if (val) {
-      this._axios.defaults.headers.common['Girder-Token'] = val;
-    } else {
-      delete this._axios.default.headers.common['Girder-Token'];
-    }
+    this.interceptors.request.use(config => ({
+      ...config,
+      baseURL: this.apiRoot,
+      headers: {
+        'Girder-Token': this.token,
+        ...config.headers,
+      },
+    }));
   }
 }

--- a/src/rest.js
+++ b/src/rest.js
@@ -12,17 +12,6 @@ export default class RestClient {
   }
 
   /**
-   * Register a callback function that will be called on error responses.
-   * @param {Function} fn The function to be called. The callback will receive
-   *     a single argument, an axios error object. If you wish to ignore the
-   *     error, return a value. If you wish to propagate the error, return
-   *     a rejected Promise with the original argument.
-   */
-  onErrorResponse(fn) {
-    this._axios.interceptors.response.use(undefined, fn);
-  }
-
-  /**
    * Use this to make Web API requests.
    * @returns An Object with the same API as axios.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,13 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -3149,7 +3156,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.2.tgz#5a9d80e0165957e5ef0c1210678fc5c4acb9fb03"
   dependencies:
@@ -4087,6 +4094,10 @@ joi@^13.0.0:
     hoek "5.x.x"
     isemail "3.x.x"
     topo "3.x.x"
+
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
 
 js-message@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
The main purpose of this topic is to decide on two runtime libraries that we'll use for REST interaction, my suggestions being:

* [axios](https://github.com/axios/axios) for dealing with XHRs
* [js-cookie](https://github.com/js-cookie/js-cookie) for dealing with cookies

As you can see from the yarn.lock changes, they don't introduce any new transitive dependencies, and they're both light, modern, popular, and well-documented.

In addition to selecting these tools, there is a minimal REST class that I envision we will use via Vue's `provide/inject` framework, e.g. 

```
import RestClient from 'girder/rest';

...
// ancestor
provide: {
   girderRest: new RestClient()
}

...
// descendant
inject: ['girderRest'],
created() {
  this.girderRest.request.get('collection').then(...)
}
```