### PR TITLE
Upload module testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vue/cli-service": "^3.0.0",
     "@vue/eslint-config-airbnb": "^3.0.0",
     "@vue/test-utils": "^1.0.0-beta.20",
+    "axios-mock-adapter": "^1.15.0",
     "chai": "^4.1.2",
     "pug": "^2.0.3",
     "pug-plain-loader": "^1.0.0",

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -21,7 +21,7 @@ export default class S3Upload {
       partEl.appendChild(etagEl);
       root.appendChild(partEl);
     });
-    return new window.XMLSerializer().serializeToString(root);
+    return root.outerHTML;
   }
 
   async _multiChunkUpload() {

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -22,7 +22,7 @@ export default class Upload {
     chunkLen = UPLOAD_CHUNK_SIZE,
   } = {}) {
     Object.assign(this, {
-      $rest, file, params, parent, progress, chunkLen, upload: null, offset: 0,
+      $rest, file, params, parent, progress, chunkLen, upload: null, offset: 0, behavior: null,
     });
   }
 
@@ -63,7 +63,8 @@ export default class Upload {
     }))).data;
 
     if (this.upload.behavior && uploadBehaviors[this.upload.behavior]) {
-      return new uploadBehaviors[this.upload.behavior](this).start();
+      this.behavior = new uploadBehaviors[this.upload.behavior](this);
+      return this.behavior.start();
     }
     return this._sendChunks();
   }
@@ -75,8 +76,8 @@ export default class Upload {
 
     this.progress({ indeterminate: true });
 
-    if (this.upload.behavior && uploadBehaviors[this.upload.behavior]) {
-      return new uploadBehaviors[this.upload.behavior](this).resume();
+    if (this.behavior) {
+      return this.behavior.resume();
     }
     this.offset = (await this.$rest.get(`file/offset?uploadId=${this.upload._id}`)).data.offset;
     return this._sendChunks();

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -14,10 +14,15 @@ export default class Upload {
    * @param opts.progress {Function} A progress callback for the upload. It will receive an Object
    * argument with either ``"indeterminate": true``, or numeric ``current`` and ``total`` fields.
    * @param opts.params {Object} Additional parameters to pass on the upload init request.
+   * @param opts.chunkLen {Number} Chunk size for sending the file (integer number of bytes).
    */
-  constructor($rest, file, parent, { progress = () => null, params = {} } = {}) {
+  constructor($rest, file, parent, {
+    progress = () => null,
+    params = {},
+    chunkLen = UPLOAD_CHUNK_SIZE,
+  } = {}) {
     Object.assign(this, {
-      $rest, file, params, parent, progress, upload: null, offset: 0,
+      $rest, file, params, parent, progress, chunkLen, upload: null, offset: 0,
     });
   }
 
@@ -29,7 +34,7 @@ export default class Upload {
     });
 
     while (this.offset < this.file.size) {
-      const end = Math.min(this.offset + UPLOAD_CHUNK_SIZE, this.file.size);
+      const end = Math.min(this.offset + this.chunkLen, this.file.size);
       const blob = this.file.slice(this.offset, end);
       const url = `file/chunk?offset=${this.offset}&uploadId=${this.upload._id}`;
       // eslint-disable-next-line no-await-in-loop

--- a/tests/unit/uploadS3.spec.js
+++ b/tests/unit/uploadS3.spec.js
@@ -1,0 +1,172 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { expect } from 'chai';
+import RestClient from '@/rest';
+import Upload from '@/utils/upload';
+
+const S3_SINGLE_CHUNK_RESP = {
+  _id: '456',
+  behavior: 's3',
+  s3: {
+    chunked: false,
+    request: {
+      method: 'PUT',
+      headers: { 'x-amz-acl': 'private' },
+      url: 'https://bucket.s3.amazonaws.com/key',
+    },
+  },
+};
+
+const S3_MULTIPART_INIT_RESP = {
+  ...S3_SINGLE_CHUNK_RESP,
+  s3: {
+    ...S3_SINGLE_CHUNK_RESP.s3,
+    chunked: true,
+    chunkLength: 8,
+    request: {
+      ...S3_SINGLE_CHUNK_RESP.s3.request,
+      method: 'POST',
+    },
+  },
+};
+
+const S3_MULTIPART_CHUNK_RESP = {
+  ...S3_SINGLE_CHUNK_RESP,
+  s3: {
+    request: {
+      url: 'https://bucket.s3.amazonaws.com/key?partNumber=i&uploadId=foo',
+      method: 'PUT',
+    },
+  },
+};
+
+const S3_MULTIPART_FINALIZE_RESP = {
+  method: 'POST',
+  url: 'https://bucket.s3.amazonaws.com/key?uploadId=foo',
+  headers: { 'Content-Type': 'text/xml' },
+};
+
+const INIT_XML = `
+<InitiateMultipartUploadResult>
+  <Bucket>bucket</Bucket>
+  <Key>key</Key>
+  <UploadId>foo</UploadId>
+</InitiateMultipartUploadResult>`;
+
+describe('S3 upload behavior', () => {
+  const rc = new RestClient();
+  const mock = new MockAdapter(rc);
+  const s3Mock = new MockAdapter(axios);
+  const blob = new Blob(['hello world'], { type: 'text/plain' });
+  blob.name = 'hello.txt';
+
+  afterEach(() => {
+    mock.reset();
+    s3Mock.reset();
+  });
+
+  after(() => {
+    s3Mock.restore();
+  });
+
+  it('successfully upload a single chunk upload', async () => {
+    mock.onPost('file').replyOnce(200, S3_SINGLE_CHUNK_RESP);
+    mock.onPost('file/completion').replyOnce(200, { _id: '789' });
+    s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(({ headers }) => {
+      expect(headers).to.have.own.property('x-amz-acl').that.equals('private');
+      return [200];
+    });
+
+    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    expect((await upload.start())._id).to.equal('789');
+  });
+
+  it('fail and resume a single-chunk upload', async () => {
+    mock.onGet(/file\/offset/).replyOnce(200, S3_SINGLE_CHUNK_RESP.s3.request);
+    mock.onPost('file').replyOnce(200, S3_SINGLE_CHUNK_RESP);
+    mock.onPost('file/completion').replyOnce(200, { _id: '789' });
+    s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(500);
+    s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(200);
+
+    let error;
+    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    try {
+      await upload.start();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).to.be.an('Error');
+    expect((await upload.resume())._id).to.equal('789');
+  });
+
+  it('fail and resume a multipart upload', async () => {
+    let finalized = false;
+    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+
+    mock.onPost('file').replyOnce(200, S3_MULTIPART_INIT_RESP);
+    mock.onPost('file/chunk').reply(200, S3_MULTIPART_CHUNK_RESP);
+    mock.onPost('file/completion').reply(200, {
+      _id: '789',
+      s3FinalizeRequest: S3_MULTIPART_FINALIZE_RESP,
+    });
+
+    // Fail once at multipart initialization
+    s3Mock.onPost(S3_MULTIPART_INIT_RESP.s3.request.url).replyOnce(500);
+    s3Mock.onPost(S3_MULTIPART_INIT_RESP.s3.request.url).replyOnce(200, INIT_XML, {
+      'Content-Type': 'text/xml',
+    });
+
+    // Fail once during a chunk upload
+    s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(500);
+    s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(200, {}, { etag: 'etag1' });
+    s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(200, {}, { etag: 'etag2' });
+
+    // Fail once at finalization
+    s3Mock.onPost(S3_MULTIPART_FINALIZE_RESP.url).replyOnce(500);
+    s3Mock.onPost(S3_MULTIPART_FINALIZE_RESP.url).replyOnce(({ data, headers }) => {
+      // Validate the multipart complete XML spec
+      const doc = new window.DOMParser().parseFromString(data, headers['Content-Type']);
+      const parts = doc.querySelectorAll('CompleteMultipartUpload > Part > PartNumber');
+      const etags = doc.querySelectorAll('CompleteMultipartUpload > Part > ETag');
+      expect(parts.length).to.equal(etags.length).to.equal(2);
+      expect([...parts].map(el => el.textContent)).to.eql(['1', '2']);
+      expect([...etags].map(el => el.textContent)).to.eql(['etag1', 'etag2']);
+
+      finalized = true;
+      return [200];
+    });
+
+    let error = null;
+    const expectError = (request) => {
+      expect(error).to.be.an('Error');
+      expect(error.config.url).to.equal(request.url);
+      expect(error.config.method.toLowerCase()).to.equal(request.method.toLowerCase());
+      error = null;
+    };
+
+    try {
+      await upload.start();
+    } catch (e) {
+      error = e;
+    }
+    expectError(S3_MULTIPART_INIT_RESP.s3.request);
+
+    try {
+      await upload.resume();
+    } catch (e) {
+      error = e;
+    }
+    expectError(S3_MULTIPART_CHUNK_RESP.s3.request);
+
+    try {
+      await upload.resume();
+    } catch (e) {
+      error = e;
+    }
+    expectError(S3_MULTIPART_FINALIZE_RESP);
+
+    // This one will now succeed
+    expect((await upload.resume())._id).to.equal('789');
+    expect(finalized).to.equal(true);
+  });
+});

--- a/tests/unit/uploadUtil.spec.js
+++ b/tests/unit/uploadUtil.spec.js
@@ -1,68 +1,14 @@
-import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
 import { parse } from 'qs';
 import RestClient from '@/rest';
 import Upload from '@/utils/upload';
 
-const S3_SINGLE_CHUNK_RESP = {
-  _id: '456',
-  behavior: 's3',
-  s3: {
-    chunked: false,
-    request: {
-      method: 'PUT',
-      headers: { 'x-amz-acl': 'private' },
-      url: 'https://bucket.s3.amazonaws.com/key',
-    },
-  },
-};
-
-const S3_MULTIPART_INIT_RESP = {
-  ...S3_SINGLE_CHUNK_RESP,
-  s3: {
-    ...S3_SINGLE_CHUNK_RESP.s3,
-    chunked: true,
-    chunkLength: 8,
-    request: {
-      ...S3_SINGLE_CHUNK_RESP.s3.request,
-      method: 'POST',
-    },
-  },
-};
-
-const S3_MULTIPART_CHUNK_RESP = {
-  ...S3_SINGLE_CHUNK_RESP,
-  s3: {
-    request: {
-      url: 'https://bucket.s3.amazonaws.com/key?partNumber=i&uploadId=foo',
-      method: 'PUT',
-    },
-  },
-};
-
-const S3_MULTIPART_FINALIZE_RESP = {
-  method: 'POST',
-  url: 'https://bucket.s3.amazonaws.com/key?uploadId=foo',
-  headers: { 'Content-Type': 'text/xml' },
-};
-
-const INIT_XML = `
-<InitiateMultipartUploadResult>
-  <Bucket>bucket</Bucket>
-  <Key>key</Key>
-  <UploadId>foo</UploadId>
-</InitiateMultipartUploadResult>`;
-
 describe('Upload module', () => {
-  let mock;
   const rc = new RestClient();
+  const mock = new MockAdapter(rc);
   const blob = new Blob(['hello world'], { type: 'text/plain' });
   blob.name = 'hello.txt';
-
-  before(() => {
-    mock = new MockAdapter(rc);
-  });
 
   afterEach(() => {
     mock.reset();
@@ -138,122 +84,5 @@ describe('Upload module', () => {
     });
     const file = await upload.resume();
     expect(file._id).to.equal('789');
-  });
-
-  describe('S3 behavior', () => {
-    let s3Mock;
-
-    before(() => {
-      s3Mock = new MockAdapter(axios);
-    });
-
-    afterEach(() => {
-      s3Mock.reset();
-    });
-
-    after(() => {
-      s3Mock.restore();
-    });
-
-    it('successfully upload a single chunk upload to S3', async () => {
-      mock.onPost('file').replyOnce(200, S3_SINGLE_CHUNK_RESP);
-      mock.onPost('file/completion').replyOnce(200, { _id: '789' });
-      s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(({ headers }) => {
-        expect(headers).to.have.own.property('x-amz-acl').that.equals('private');
-        return [200];
-      });
-
-      const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
-      expect((await upload.start())._id).to.equal('789');
-    });
-
-    it('fail and resume a single-chunk S3 upload', async () => {
-      mock.onGet(/file\/offset/).replyOnce(200, S3_SINGLE_CHUNK_RESP.s3.request);
-      mock.onPost('file').replyOnce(200, S3_SINGLE_CHUNK_RESP);
-      mock.onPost('file/completion').replyOnce(200, { _id: '789' });
-      s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(500);
-      s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(200);
-
-      let error;
-      const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
-      try {
-        await upload.start();
-      } catch (e) {
-        error = e;
-      }
-      expect(error).to.be.an('Error');
-      expect((await upload.resume())._id).to.equal('789');
-    });
-
-    it('fail and resume a multipart S3 upload', async () => {
-      let finalized = false;
-      const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
-
-      mock.onPost('file').replyOnce(200, S3_MULTIPART_INIT_RESP);
-      mock.onPost('file/chunk').reply(200, S3_MULTIPART_CHUNK_RESP);
-      mock.onPost('file/completion').reply(200, {
-        _id: '789',
-        s3FinalizeRequest: S3_MULTIPART_FINALIZE_RESP,
-      });
-
-      // Fail once at multipart initialization
-      s3Mock.onPost(S3_MULTIPART_INIT_RESP.s3.request.url).replyOnce(500);
-      s3Mock.onPost(S3_MULTIPART_INIT_RESP.s3.request.url).replyOnce(200, INIT_XML, {
-        'Content-Type': 'text/xml',
-      });
-
-      // Fail once during a chunk upload
-      s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(500);
-      s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(200, {}, { etag: 'etag1' });
-      s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(200, {}, { etag: 'etag2' });
-
-      // Fail once at finalization
-      s3Mock.onPost(S3_MULTIPART_FINALIZE_RESP.url).replyOnce(500);
-      s3Mock.onPost(S3_MULTIPART_FINALIZE_RESP.url).replyOnce(({ data, headers }) => {
-        // Validate the multipart complete XML spec
-        const doc = new window.DOMParser().parseFromString(data, headers['Content-Type']);
-        const parts = doc.querySelectorAll('CompleteMultipartUpload > Part > PartNumber');
-        const etags = doc.querySelectorAll('CompleteMultipartUpload > Part > ETag');
-        expect(parts.length).to.equal(etags.length).to.equal(2);
-        expect([...parts].map(el => el.textContent)).to.eql(['1', '2']);
-        expect([...etags].map(el => el.textContent)).to.eql(['etag1', 'etag2']);
-
-        finalized = true;
-        return [200];
-      });
-
-      let error = null;
-      const expectError = (request) => {
-        expect(error).to.be.an('Error');
-        expect(error.config.url).to.equal(request.url);
-        expect(error.config.method.toLowerCase()).to.equal(request.method.toLowerCase());
-        error = null;
-      };
-
-      try {
-        await upload.start();
-      } catch (e) {
-        error = e;
-      }
-      expectError(S3_MULTIPART_INIT_RESP.s3.request);
-
-      try {
-        await upload.resume();
-      } catch (e) {
-        error = e;
-      }
-      expectError(S3_MULTIPART_CHUNK_RESP.s3.request);
-
-      try {
-        await upload.resume();
-      } catch (e) {
-        error = e;
-      }
-      expectError(S3_MULTIPART_FINALIZE_RESP)
-
-      // This one will now succeed
-      expect((await upload.resume())._id).to.equal('789');
-      expect(finalized).to.equal(true);
-    });
   });
 });

--- a/tests/unit/uploadUtil.spec.js
+++ b/tests/unit/uploadUtil.spec.js
@@ -1,8 +1,58 @@
+import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
 import { parse } from 'qs';
 import RestClient from '@/rest';
 import Upload from '@/utils/upload';
+
+const S3_SINGLE_CHUNK_RESP = {
+  _id: '456',
+  behavior: 's3',
+  s3: {
+    chunked: false,
+    request: {
+      method: 'PUT',
+      headers: { 'x-amz-acl': 'private' },
+      url: 'https://bucket.s3.amazonaws.com/key',
+    },
+  },
+};
+
+const S3_MULTIPART_INIT_RESP = {
+  ...S3_SINGLE_CHUNK_RESP,
+  s3: {
+    ...S3_SINGLE_CHUNK_RESP.s3,
+    chunked: true,
+    chunkLength: 8,
+    request: {
+      ...S3_SINGLE_CHUNK_RESP.s3.request,
+      method: 'POST',
+    },
+  },
+};
+
+const S3_MULTIPART_CHUNK_RESP = {
+  ...S3_SINGLE_CHUNK_RESP,
+  s3: {
+    request: {
+      url: 'https://bucket.s3.amazonaws.com/key?partNumber=i&uploadId=foo',
+      method: 'PUT',
+    },
+  },
+};
+
+const S3_MULTIPART_FINALIZE_RESP = {
+  method: 'POST',
+  url: 'https://bucket.s3.amazonaws.com/key?uploadId=foo',
+  headers: { 'Content-Type': 'text/xml' },
+};
+
+const INIT_XML = `
+<InitiateMultipartUploadResult>
+  <Bucket>bucket</Bucket>
+  <Key>key</Key>
+  <UploadId>foo</UploadId>
+</InitiateMultipartUploadResult>`;
 
 describe('Upload module', () => {
   let mock;
@@ -16,10 +66,6 @@ describe('Upload module', () => {
 
   afterEach(() => {
     mock.reset();
-  });
-
-  after(() => {
-    mock.restore();
   });
 
   it('successfully upload a single-chunk file', async () => {
@@ -43,8 +89,7 @@ describe('Upload module', () => {
     });
 
     const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
-    const file = await upload.start();
-    expect(file._id).to.equal('789');
+    expect((await upload.start())._id).to.equal('789');
   });
 
   it('fail during init step and resume', async () => {
@@ -95,15 +140,120 @@ describe('Upload module', () => {
     expect(file._id).to.equal('789');
   });
 
-  it('successfully upload a single chunk upload to S3', async () => {
-    // TODO
-  });
+  describe('S3 behavior', () => {
+    let s3Mock;
 
-  it('fail and resume a single-chunk S3 upload', async () => {
-    // TODO
-  });
+    before(() => {
+      s3Mock = new MockAdapter(axios);
+    });
 
-  it('fail and resume a multipart S3 upload', async () => {
-    // TODO
+    afterEach(() => {
+      s3Mock.reset();
+    });
+
+    after(() => {
+      s3Mock.restore();
+    });
+
+    it('successfully upload a single chunk upload to S3', async () => {
+      mock.onPost('file').replyOnce(200, S3_SINGLE_CHUNK_RESP);
+      mock.onPost('file/completion').replyOnce(200, { _id: '789' });
+      s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(({ headers }) => {
+        expect(headers).to.have.own.property('x-amz-acl').that.equals('private');
+        return [200];
+      });
+
+      const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+      expect((await upload.start())._id).to.equal('789');
+    });
+
+    it('fail and resume a single-chunk S3 upload', async () => {
+      mock.onGet(/file\/offset/).replyOnce(200, S3_SINGLE_CHUNK_RESP.s3.request);
+      mock.onPost('file').replyOnce(200, S3_SINGLE_CHUNK_RESP);
+      mock.onPost('file/completion').replyOnce(200, { _id: '789' });
+      s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(500);
+      s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(200);
+
+      let error;
+      const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+      try {
+        await upload.start();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.be.an('Error');
+      expect((await upload.resume())._id).to.equal('789');
+    });
+
+    it('fail and resume a multipart S3 upload', async () => {
+      let finalized = false;
+      const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+
+      mock.onPost('file').replyOnce(200, S3_MULTIPART_INIT_RESP);
+      mock.onPost('file/chunk').reply(200, S3_MULTIPART_CHUNK_RESP);
+      mock.onPost('file/completion').reply(200, {
+        _id: '789',
+        s3FinalizeRequest: S3_MULTIPART_FINALIZE_RESP,
+      });
+
+      // Fail once at multipart initialization
+      s3Mock.onPost(S3_MULTIPART_INIT_RESP.s3.request.url).replyOnce(500);
+      s3Mock.onPost(S3_MULTIPART_INIT_RESP.s3.request.url).replyOnce(200, INIT_XML, {
+        'Content-Type': 'text/xml',
+      });
+
+      // Fail once during a chunk upload
+      s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(500);
+      s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(200, {}, { etag: 'etag1' });
+      s3Mock.onPut(S3_MULTIPART_CHUNK_RESP.s3.request.url).replyOnce(200, {}, { etag: 'etag2' });
+
+      // Fail once at finalization
+      s3Mock.onPost(S3_MULTIPART_FINALIZE_RESP.url).replyOnce(500);
+      s3Mock.onPost(S3_MULTIPART_FINALIZE_RESP.url).replyOnce(({ data, headers }) => {
+        // Validate the multipart complete XML spec
+        const doc = new window.DOMParser().parseFromString(data, headers['Content-Type']);
+        const parts = doc.querySelectorAll('CompleteMultipartUpload > Part > PartNumber');
+        const etags = doc.querySelectorAll('CompleteMultipartUpload > Part > ETag');
+        expect(parts.length).to.equal(etags.length).to.equal(2);
+        expect([...parts].map(el => el.textContent)).to.eql(['1', '2']);
+        expect([...etags].map(el => el.textContent)).to.eql(['etag1', 'etag2']);
+
+        finalized = true;
+        return [200];
+      });
+
+      let error = null;
+      const expectError = (request) => {
+        expect(error).to.be.an('Error');
+        expect(error.config.url).to.equal(request.url);
+        expect(error.config.method.toLowerCase()).to.equal(request.method.toLowerCase());
+        error = null;
+      };
+
+      try {
+        await upload.start();
+      } catch (e) {
+        error = e;
+      }
+      expectError(S3_MULTIPART_INIT_RESP.s3.request);
+
+      try {
+        await upload.resume();
+      } catch (e) {
+        error = e;
+      }
+      expectError(S3_MULTIPART_CHUNK_RESP.s3.request);
+
+      try {
+        await upload.resume();
+      } catch (e) {
+        error = e;
+      }
+      expectError(S3_MULTIPART_FINALIZE_RESP)
+
+      // This one will now succeed
+      expect((await upload.resume())._id).to.equal('789');
+      expect(finalized).to.equal(true);
+    });
   });
 });

--- a/tests/unit/uploadUtil.spec.js
+++ b/tests/unit/uploadUtil.spec.js
@@ -1,0 +1,109 @@
+import MockAdapter from 'axios-mock-adapter';
+import { expect } from 'chai';
+import { parse } from 'qs';
+import RestClient from '@/rest';
+import Upload from '@/utils/upload';
+
+describe('Upload module', () => {
+  let mock;
+  const rc = new RestClient();
+  const blob = new Blob(['hello world'], { type: 'text/plain' });
+  blob.name = 'hello.txt';
+
+  before(() => {
+    mock = new MockAdapter(rc);
+  });
+
+  afterEach(() => {
+    mock.reset();
+  });
+
+  after(() => {
+    mock.restore();
+  });
+
+  it('successfully upload a single-chunk file', async () => {
+    mock.onPost('file').reply(({ data, headers }) => {
+      expect(headers['Content-Type']).to.equal('application/x-www-form-urlencoded');
+
+      const params = parse(data);
+      expect(parseInt(params.size, 10)).to.equal(blob.size).to.equal('hello world'.length);
+      expect(params.parentType).to.equal('folder');
+      expect(params.parentId).to.equal('123');
+      expect(params.mimeType).to.equal('text/plain');
+      expect(params.name).to.equal('hello.txt');
+      return [200, { _id: '456' }];
+    });
+
+    mock.onPost(/file\/chunk/).reply(({ url }) => {
+      const params = parse(url.split('?')[1]);
+      expect(params.uploadId).to.equal('456');
+      expect(parseInt(params.offset, 10)).to.equal(0);
+      return [200, { _id: '789' }];
+    });
+
+    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    const file = await upload.start();
+    expect(file._id).to.equal('789');
+  });
+
+  it('fail during init step and resume', async () => {
+    mock.onPost('file').networkError();
+
+    let error;
+    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+
+    try {
+      await upload.start();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).to.be.an('Error');
+
+    mock.reset();
+    mock.onPost('file').replyOnce(200, { _id: '456' });
+    mock.onPost(/file\/chunk/).replyOnce(200, { _id: '789' });
+
+    const file = await upload.resume();
+    expect(file._id).to.equal('789');
+  });
+
+  it('first chunk succeeds, second chunk fails', async () => {
+    mock.onPost('file').replyOnce(200, { _id: '456' });
+    mock.onPost(/file\/chunk/).replyOnce(200, { _id: '456' });
+    mock.onPost(/file\/chunk/).replyOnce(500, { message: 'Internal error' });
+
+    let error;
+    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' }, { chunkLen: 8 });
+
+    try {
+      await upload.start();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).to.be.an('Error');
+    expect(error.response.data.message).to.equal('Internal error');
+    expect(upload.offset).to.equal(8);
+
+    mock.onGet(/file\/offset/).replyOnce(200, { offset: 8 });
+    mock.onPost(/file\/chunk/).replyOnce(({ data }) => {
+      expect(data).to.be.a('Blob');
+      expect(data.size).to.equal(3);
+      return [200, { _id: '789' }];
+    });
+    const file = await upload.resume();
+    expect(file._id).to.equal('789');
+  });
+
+  it('successfully upload a single chunk upload to S3', async () => {
+    // TODO
+  });
+
+  it('fail and resume a single-chunk S3 upload', async () => {
+    // TODO
+  });
+
+  it('fail and resume a multipart S3 upload', async () => {
+    // TODO
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,12 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axios-mock-adapter@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.15.0.tgz#fbc06825d8302c95c3334d21023bba996255d45d"
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"


### PR DESCRIPTION
This adds some unit testing of the upload module, and attempts to establish some practices surrounding mocking. I've chosen to use the [axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter) package rather than the more first-class [moxios](https://github.com/axios/moxios) because it seems nicer to use and is also more popular.

Naturally, adding testing did uncover an actual bug, on which I'll comment inline.