### PR TITLE
Build this library as a UMD module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,17 @@
-# girder-lib
+# Girder web component library
 
-## Project setup
-```
-yarn
-```
+## For developers
+### Project setup
+    yarn
 
-### Compiles and hot-reloads for development
-```
-yarn serve
-```
+#### Compile and hot-reload for development
+    yarn serve
 
-### Compiles and minifies for production
-```
-yarn build
-```
+#### Build the library for production
+    yarn build
 
-### Lints and fixes files
-```
-yarn lint
-```
+### Lint and fix source code
+    yarn lint
 
-### Run your unit tests
-```
-yarn test:unit
-```
+### Run unit tests
+    yarn test:unit

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "girder-lib",
   "version": "0.1.0",
-  "private": true,
+  "main": "dist/girder.umd.min.js",
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build --target lib --name girder src/index.js",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,7 +4,6 @@ import 'vuetify/dist/vuetify.min.css';
 import Upload from './Upload.vue';
 
 Vue.use(Vuetify);
-Vue.config.productionTip = false;
 
 export default {
   Upload,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,11 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import 'vuetify/dist/vuetify.min.css';
+import Upload from './Upload.vue';
+
+Vue.use(Vuetify);
+Vue.config.productionTip = false;
+
+export default {
+  Upload,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,11 @@
+import components from './components';
+import * as constants from './constants';
+import RestClient from './rest';
+import utils from './utils';
+
+export {
+  components,
+  constants,
+  RestClient,
+  utils,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,6 @@ import RestClient from './rest';
 const girderRest = new RestClient({ apiRoot: 'http://localhost:8080/api/v1' });
 
 Vue.use(Vuetify);
-Vue.config.productionTip = false;
 
 girderRest.fetchUser().then(() => {
   new Vue({

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,7 @@
+import * as mixins from './mixins';
+import Upload from './upload';
+
+export default {
+  mixins,
+  Upload,
+};


### PR DESCRIPTION
The `build` command now builds a UMD library target rather than the example app (which will still be what you see via `yarn serve`, though we can certainly add another script for building the example).

In addition to being able to import this into node or a downstream webpack build, this means the library can now be imported into the browser directly, as in the following example, which was working when I included the App.vue component in the library exports.

```
<meta charset="utf-8">
<title>girder demo</title>
<script src="https://unpkg.com/vue"></script>
<script src="./girder.umd.js"></script>
<link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
<link rel="stylesheet" href="./girder.css">
<div id="app"></div>
<script>
const girderRest = new girder.RestClient({ apiRoot: 'http://localhost:8080/api/v1' });
girderRest.fetchUser().then(() => {
  new Vue({
    render: h => h(girder.App),
    provide: { girderRest },
  }).$mount('#app');
});
</script>
```

Note that Vue is externalized by design under vue-cli-service v3.

