### PR TITLE
Auth should forget password after successful login or session change.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ v-app.app
     girder-auth(
         :register="true",
         :oauth="true",
+        :key="girderRest.token",
         :forgot-password-url="forgotPasswordUrl")
   v-dialog(v-model="uploader", full-width, max-width="800px")
     girder-upload(

--- a/src/components/Authentication/Login.vue
+++ b/src/components/Authentication/Login.vue
@@ -82,6 +82,7 @@ export default {
       this.inProgress = true;
       try {
         await this.girderRest.login(this.username, this.password);
+        this.password = '';
       } catch (err) {
         if (!err.response || err.response.status !== 401) {
           this.alerts.errors.push('Unknown error.');


### PR DESCRIPTION
Currently after login/logout, a user's password still exists in component state and can be retrieved with console access.

This adds 2 redundant behaviors:

* On successful login, the component will automatically clear the password field.
* On session change (such as a login) the entire component will be destroyed.   I think this is a good practice to also clear the username field and whatever other state has accumulated, but there may be reasons not to do this, so the decision is left up to the app developer.