### PR TITLE
Disallow '@' alias for local imports in src tree

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-restricted-imports": ["error", { "patterns": ["@/*"] }]
+  }
+}


### PR DESCRIPTION
As promised, here's a linter rule that ensures we don't use the `@` alias within the `src` directory. Since the `vue-cli-service lint` command also lints the test directory, and we need that alias there, this rule cannot be applied to all directories. I assume it's also possible to put this in package.json and just override it in the test dir and any other dirs we need it, but this feels easier.