### PR TITLE
Separate demo

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VUE_APP_API_ROOT=http://localhost:8080/api/v1

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_API_ROOT=https://data.kitware.com/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 /coverage/
 /dist/
+/_site/
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This will expose all the library's components under the global variable `girder`
 
 #### Girder RestClient
 
-Many components in this library will require a `RestClient` named `girderRest` through provide/inject.  
+Many components in this library will require a `RestClient` named `girderRest` through provide/inject.
 The client can be provided through any common ancestor.  For example:
 
 ```javascript
@@ -47,7 +47,7 @@ new Vue({
 
 #### Components
 
-If you're building your own downstream application, you can include individual components from the library. Because these are vuetify components, your consumer application is responsible for creating the `v-app` container.  [Read more](https://vuetifyjs.com/en/layout/pre-defined#all-about-app).  See `src/main.js` for a more comprehensive example.
+If you're building your own downstream application, you can include individual components from the library. Because these are vuetify components, your consumer application is responsible for creating the `v-app` container.  [Read more](https://vuetifyjs.com/en/layout/pre-defined#all-about-app).  See `demo/main.js` for a more comprehensive example.
 
 Either import the full UMD module:
 

--- a/README.md
+++ b/README.md
@@ -149,3 +149,17 @@ yarn lint
 # Run unit tests
 yarn test:unit
 ```
+
+### Use an external Girder API
+
+To build the demo app against an external Girder API, set the
+`VUE_APP_API_ROOT` environment variable. For example:
+
+```bash
+export VUE_APP_API_ROOT=https://data.kitware.com/api/v1
+yarn serve
+```
+
+This variable value defaults to `http://localhost:8080/api/v1` for
+normal development (which assumes the developer has a local instance of
+the Girder API server running).

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -48,7 +48,7 @@ import {
   DataBrowser as GirderDataBrowser,
   Upload as GirderUpload,
   UpsertFolder as GirderUpsertFolder,
-} from './components';
+} from '@/components';
 
 export default {
   name: 'App',

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Girder from '@';
-import App from './App.vue';
 import RestClient from '@/rest';
+import App from './App.vue';
 
 Vue.use(Girder);
 const girderRest = new RestClient({

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
-import Girder from '.';
+import Girder from '@';
 import App from './App.vue';
-import RestClient from './rest';
+import RestClient from '@/rest';
 
 Vue.use(Girder);
 const girderRest = new RestClient({

--- a/demo/main.js
+++ b/demo/main.js
@@ -5,9 +5,7 @@ import RestClient from '@/rest';
 
 Vue.use(Girder);
 const girderRest = new RestClient({
-  apiRoot: process.env.NODE_ENV === 'production'
-    ? 'https://data.kitware.com/api/v1'
-    : 'http://localhost:8080/api/v1',
+  apiRoot: process.env.VUE_APP_API_ROOT,
 });
 
 girderRest.fetchUser().then(() => {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "Apache-2.0",
   "main": "dist/girder.umd.min.js",
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",
-    "build:demo": "vue-cli-service build --dest _site/",
+    "build:demo": "vue-cli-service build --dest _site/ demo/main.js",
     "lint": "vue-cli-service lint",
     "lint:pug": "pug-lint-vue src",
     "lint:style": "stylelint 'src/**/*.vue'",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",
     "build:demo": "vue-cli-service build --dest _site/ demo/main.js",
-    "lint": "vue-cli-service lint",
-    "lint:pug": "pug-lint-vue src",
-    "lint:style": "stylelint 'src/**/*.vue'",
+    "lint": "vue-cli-service lint src/ tests/ demo/ '*.js' '.*.js' '{src,tests,demo}/**/.*.js'",
+    "lint:pug": "pug-lint-vue src/ demo/",
+    "lint:style": "stylelint 'src/**/*.vue' 'demo/**/*.vue'",
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {


### PR DESCRIPTION
* Gitignore built demo site files
* Move demo site files to a separate directory
* Set demo app API root from environment
* Ensure demo files are linted
  * Default "vue-cli-service lint" paths are in: https://github.com/vuejs/vue-cli/blob/v3.0.4/packages/@vue/cli-plugin-eslint/lint.js#L18

Fixes #77 