### PR TITLE
Remove unused style rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     ],
     "rules": {
       "no-param-reassign": ["error", { "props": false }],
-      "no-underscore-dangle": 0,
-      "import/prefer-default-export": 0
+      "no-underscore-dangle": 0
     },
     "parserOptions": {
       "parser": "babel-eslint"


### PR DESCRIPTION
Refs #95. We don't need this rule right now, and I propose removing it globally in favor of inline overrides.