### PR TITLE
Upload subclassing

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -149,6 +149,13 @@ export default {
             results.push(file.result);
             file.status = 'done';
           } catch (error) {
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.onError({
+              error,
+              current: i,
+              total: this.files.length,
+            });
+
             if (error.response) {
               this.errorMessage = error.response.data.message || 'An error occurred during upload.';
             } else {

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -53,12 +53,8 @@ export default {
       default: true,
       type: Boolean,
     },
-    preUpload: {
-      default: () => {},
-      type: Function,
-    },
-    postUpload: {
-      default: () => {},
+    uploadCls: {
+      default: Upload,
       type: Function,
     },
     accept: {
@@ -114,7 +110,7 @@ export default {
       const results = [];
       this.uploading = true;
       this.errorMessage = null;
-      await this.preUpload();
+
       for (let i = 0; i < this.files.length; i += 1) {
         const file = this.files[i];
         if (file.status === 'done') {
@@ -130,10 +126,25 @@ export default {
               // eslint-disable-next-line no-await-in-loop
               file.result = await file.upload.resume();
             } else {
-              file.upload = new Upload(this.girderRest, file.file, this.dest, { progress });
+              // eslint-disable-next-line new-cap
+              file.upload = new this.uploadCls(file.file, {
+                $rest: this.girderRest,
+                parent: this.dest,
+                progress,
+              });
+              // eslint-disable-next-line no-await-in-loop
+              await file.upload.beforeUpload({
+                current: i,
+                total: this.files.length,
+              });
               // eslint-disable-next-line no-await-in-loop
               file.result = await file.upload.start();
             }
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.afterUpload({
+              current: i,
+              total: this.files.length,
+            });
             delete file.upload;
             results.push(file.result);
             file.status = 'done';
@@ -150,7 +161,6 @@ export default {
           }
         }
       }
-      await this.postUpload();
       this.uploading = false;
       this.files = [];
       this.$emit('done', results);

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -90,4 +90,7 @@ export default class Upload {
 
   // eslint-disable-next-line class-methods-use-this
   afterUpload() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  onError() {}
 }

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -88,10 +88,7 @@ export default class Upload {
   /**
    * This callback is called before the upload is started. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
-   * This callback is passed the index of this file in the overall list of files being uploaded,
-   * which is mostly done to allow asynchronous hooks to be performed only before the first file or
-   * after the last file, which is a common use case.
-   * @param current {Number} The index of this file in the list.
+   * @param current {Number} The index of this file in the list of files being uploaded.
    * @param total {Number} The total number of files being uploaded.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
@@ -100,10 +97,7 @@ export default class Upload {
   /**
    * This callback is called after the upload is completed. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
-   * This callback is passed the index of this file in the overall list of files being uploaded,
-   * which is mostly done to allow asynchronous hooks to be performed only before the first file or
-   * after the last file, which is a common use case.
-   * @param current {Number} The index of this file in the list.
+   * @param current {Number} The index of this file in the list of files being uploaded.
    * @param total {Number} The total number of files being uploaded.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
@@ -112,9 +106,8 @@ export default class Upload {
   /**
    * This callback is called if an error occurs during the upload. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
-   * This callback is passed the index of this file in the overall list of files being uploaded.
    * @param error {Exception} The exception object.
-   * @param current {Number} The index of this file in the list.
+   * @param current {Number} The index of this file in the list of files being uploaded.
    * @param total {Number} The total number of files being uploaded.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -7,16 +7,18 @@ const uploadBehaviors = { s3: S3Upload };
 export default class Upload {
   /**
    * Represents an upload of a single file to the server.
-   * @param $rest {Object} an axios instance used for communicating with Girder.
    * @param file {File | Blob} the file to upload
-   * @param parent {Object} upload destination. Must have ``_id`` and ``_modelType`` properties.
    * @param opts {Object} upload options.
+   * @param opts.$rest {Object} an axios instance used for communicating with Girder.
+   * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
    * @param opts.progress {Function} A progress callback for the upload. It will receive an Object
-   * argument with either ``"indeterminate": true``, or numeric ``current`` and ``total`` fields.
+   *   argument with either ``"indeterminate": true``, or numeric ``current`` and ``total`` fields.
    * @param opts.params {Object} Additional parameters to pass on the upload init request.
    * @param opts.chunkLen {Number} Chunk size for sending the file (integer number of bytes).
    */
-  constructor($rest, file, parent, {
+  constructor(file, {
+    $rest,
+    parent,
     progress = () => null,
     params = {},
     chunkLen = UPLOAD_CHUNK_SIZE,
@@ -82,4 +84,10 @@ export default class Upload {
     this.offset = (await this.$rest.get(`file/offset?uploadId=${this.upload._id}`)).data.offset;
     return this._sendChunks();
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  beforeUpload() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  afterUpload() {}
 }

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -85,12 +85,38 @@ export default class Upload {
     return this._sendChunks();
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  beforeUpload() {}
+  /**
+   * This callback is called before the upload is started. This callback is asynchronous.
+   * If it returns a Promise, the caller will await its resolution before continuing.
+   * This callback is passed the index of this file in the overall list of files being uploaded,
+   * which is mostly done to allow asynchronous hooks to be performed only before the first file or
+   * after the last file, which is a common use case.
+   * @param current {Number} The index of this file in the list.
+   * @param total {Number} The total number of files being uploaded.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  beforeUpload({ current, total }) {}
 
-  // eslint-disable-next-line class-methods-use-this
-  afterUpload() {}
+  /**
+   * This callback is called after the upload is completed. This callback is asynchronous.
+   * If it returns a Promise, the caller will await its resolution before continuing.
+   * This callback is passed the index of this file in the overall list of files being uploaded,
+   * which is mostly done to allow asynchronous hooks to be performed only before the first file or
+   * after the last file, which is a common use case.
+   * @param current {Number} The index of this file in the list.
+   * @param total {Number} The total number of files being uploaded.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  afterUpload({ current, total }) {}
 
-  // eslint-disable-next-line class-methods-use-this
-  onError() {}
+  /**
+   * This callback is called if an error occurs during the upload. This callback is asynchronous.
+   * If it returns a Promise, the caller will await its resolution before continuing.
+   * This callback is passed the index of this file in the overall list of files being uploaded.
+   * @param error {Exception} The exception object.
+   * @param current {Number} The index of this file in the list.
+   * @param total {Number} The total number of files being uploaded.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  onError({ error, current, total }) {}
 }

--- a/tests/unit/uploadS3.spec.js
+++ b/tests/unit/uploadS3.spec.js
@@ -53,8 +53,8 @@ const INIT_XML = `
 </InitiateMultipartUploadResult>`;
 
 describe('S3 upload behavior', () => {
-  const rc = new RestClient();
-  const mock = new MockAdapter(rc);
+  const $rest = new RestClient();
+  const mock = new MockAdapter($rest);
   const s3Mock = new MockAdapter(axios);
   const blob = new Blob(['hello world'], { type: 'text/plain' });
   blob.name = 'hello.txt';
@@ -72,7 +72,10 @@ describe('S3 upload behavior', () => {
       return [200];
     });
 
-    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    const upload = new Upload(blob, {
+      $rest,
+      parent: { _id: '123', _modelType: 'folder' },
+    });
     expect((await upload.start())._id).toBe('789');
   });
 
@@ -84,7 +87,10 @@ describe('S3 upload behavior', () => {
     s3Mock.onPut(S3_SINGLE_CHUNK_RESP.s3.request.url).replyOnce(200);
 
     let error;
-    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    const upload = new Upload(blob, {
+      $rest,
+      parent: { _id: '123', _modelType: 'folder' },
+    });
     try {
       await upload.start();
     } catch (e) {
@@ -96,7 +102,10 @@ describe('S3 upload behavior', () => {
 
   it('fail and resume a multipart upload', async () => {
     let finalized = false;
-    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    const upload = new Upload(blob, {
+      $rest,
+      parent: { _id: '123', _modelType: 'folder' },
+    });
 
     mock.onPost('file').replyOnce(200, S3_MULTIPART_INIT_RESP);
     mock.onPost('file/chunk').reply(200, S3_MULTIPART_CHUNK_RESP);

--- a/tests/unit/uploadUtil.spec.js
+++ b/tests/unit/uploadUtil.spec.js
@@ -4,8 +4,8 @@ import RestClient from '@/rest';
 import Upload from '@/utils/upload';
 
 describe('Upload module', () => {
-  const rc = new RestClient();
-  const mock = new MockAdapter(rc);
+  const $rest = new RestClient();
+  const mock = new MockAdapter($rest);
   const blob = new Blob(['hello world'], { type: 'text/plain' });
   blob.name = 'hello.txt';
 
@@ -34,7 +34,10 @@ describe('Upload module', () => {
       return [200, { _id: '789' }];
     });
 
-    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    const upload = new Upload(blob, {
+      $rest,
+      parent: { _id: '123', _modelType: 'folder' },
+    });
     expect((await upload.start())._id).toBe('789');
   });
 
@@ -42,7 +45,10 @@ describe('Upload module', () => {
     mock.onPost('file').networkError();
 
     let error;
-    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' });
+    const upload = new Upload(blob, {
+      $rest,
+      parent: { _id: '123', _modelType: 'folder' },
+    });
 
     try {
       await upload.start();
@@ -65,7 +71,11 @@ describe('Upload module', () => {
     mock.onPost(/file\/chunk/).replyOnce(500, { message: 'Internal error' });
 
     let error;
-    const upload = new Upload(rc, blob, { _id: '123', _modelType: 'folder' }, { chunkLen: 8 });
+    const upload = new Upload(blob, {
+      $rest,
+      parent: { _id: '123', _modelType: 'folder' },
+      chunkLen: 8,
+    });
 
     try {
       await upload.start();


### PR DESCRIPTION
This isn't intended to be merged as is, just to show a rough idea of what I'm talking about on #94.

With this interface, downstreams could subclass the Upload class and pass it into the Upload component to control behavior. This also adds 3 hook points into the upload class that are no-ops by default. These hooks would allow things like:

* Perform an action (synchronous or asynchronous) before the first upload.
* Perform an action before *each* upload, or only certain uploads, based on filename or other file properties of the file.
* Perform an action after the *last* upload is done.
* Perform an action if an error occurs during upload.

If we allow these hooks to return values, they could also be used to further augment the behavior of the component, e.g. skipping certain files, or showing custom errors. This concept would need to be fleshed out further, but we don't have to do it right now, as we could introduce that kind of control without breaking this API.

Note that the need for `preUpload` and `postUpload` callback props on the component is obviated.

If the general idea is palatable, I'll write a unit test that creates a subclass and exercises the hooks.