### PR TITLE
Upload class optional members

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -52,6 +52,14 @@ export default {
       default: true,
       type: Boolean,
     },
+    preUpload: {
+      default: () => {},
+      type: Function,
+    },
+    postUpload: {
+      default: () => {},
+      type: Function,
+    },
     uploadCls: {
       default: Upload,
       type: Function,
@@ -108,7 +116,7 @@ export default {
       const results = [];
       this.uploading = true;
       this.errorMessage = null;
-
+      await this.preUpload();
       for (let i = 0; i < this.files.length; i += 1) {
         const file = this.files[i];
         if (file.status === 'done') {
@@ -175,6 +183,7 @@ export default {
           }
         }
       }
+      await this.postUpload();
       this.uploading = false;
       this.files = [];
       this.$emit('done', results);

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -144,6 +144,13 @@ export default {
             results.push(file.result);
             file.status = 'done';
           } catch (error) {
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.onError({
+              error,
+              current: i,
+              total: this.files.length,
+            });
+
             if (error.response) {
               this.errorMessage = error.response.data.message || 'An error occurred during upload.';
             } else {

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -78,7 +78,7 @@ export default {
       return `${this.files.length} selected (${this.formatSize(this.totalSize)} total)`;
     },
     totalProgress() {
-      return this.files.reduce((v, f) => v + (f.progress.current || 0), 0);
+      return this.files.reduce((v, f) => v + (f.progress.current), 0);
     },
     totalSize() {
       return this.files.reduce((v, f) => v + f.file.size, 0);
@@ -95,7 +95,10 @@ export default {
       this.files = files.map(file => ({
         file,
         status: 'pending',
-        progress: {},
+        progress: {
+          indeterminate: false,
+          current: 0,
+        },
         upload: null,
         result: null,
       }));
@@ -113,7 +116,7 @@ export default {
           results.push(file.result);
         } else {
           const progress = (event) => {
-            file.progress = Object.assign({}, file.progress, event);
+            Object.assign(file.progress, event);
           };
           file.status = 'uploading';
           try {

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -52,12 +52,8 @@ export default {
       default: true,
       type: Boolean,
     },
-    preUpload: {
-      default: () => {},
-      type: Function,
-    },
-    postUpload: {
-      default: () => {},
+    uploadCls: {
+      default: Upload,
       type: Function,
     },
   },
@@ -109,7 +105,7 @@ export default {
       const results = [];
       this.uploading = true;
       this.errorMessage = null;
-      await this.preUpload();
+
       for (let i = 0; i < this.files.length; i += 1) {
         const file = this.files[i];
         if (file.status === 'done') {
@@ -125,10 +121,25 @@ export default {
               // eslint-disable-next-line no-await-in-loop
               file.result = await file.upload.resume();
             } else {
-              file.upload = new Upload(this.girderRest, file.file, this.dest, { progress });
+              // eslint-disable-next-line new-cap
+              file.upload = new this.uploadCls(file.file, {
+                $rest: this.girderRest,
+                parent: this.dest,
+                progress,
+              });
+              // eslint-disable-next-line no-await-in-loop
+              await file.upload.beforeUpload({
+                current: i,
+                total: this.files.length,
+              });
               // eslint-disable-next-line no-await-in-loop
               file.result = await file.upload.start();
             }
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.afterUpload({
+              current: i,
+              total: this.files.length,
+            });
             delete file.upload;
             results.push(file.result);
             file.status = 'done';
@@ -145,7 +156,6 @@ export default {
           }
         }
       }
-      await this.postUpload();
       this.uploading = false;
       this.files = [];
       this.$emit('done', results);

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -90,4 +90,7 @@ export default class Upload {
 
   // eslint-disable-next-line class-methods-use-this
   afterUpload() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  onError() {}
 }

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -7,16 +7,18 @@ const uploadBehaviors = { s3: S3Upload };
 export default class Upload {
   /**
    * Represents an upload of a single file to the server.
-   * @param $rest {Object} an axios instance used for communicating with Girder.
    * @param file {File | Blob} the file to upload
-   * @param parent {Object} upload destination. Must have ``_id`` and ``_modelType`` properties.
    * @param opts {Object} upload options.
+   * @param opts.$rest {Object} an axios instance used for communicating with Girder.
+   * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
    * @param opts.progress {Function} A progress callback for the upload. It will receive an Object
-   * argument with either ``"indeterminate": true``, or numeric ``current`` and ``total`` fields.
+   *   argument with either ``"indeterminate": true``, or numeric ``current`` and ``total`` fields.
    * @param opts.params {Object} Additional parameters to pass on the upload init request.
    * @param opts.chunkLen {Number} Chunk size for sending the file (integer number of bytes).
    */
-  constructor($rest, file, parent, {
+  constructor(file, {
+    $rest,
+    parent,
     progress = () => null,
     params = {},
     chunkLen = UPLOAD_CHUNK_SIZE,
@@ -82,4 +84,10 @@ export default class Upload {
     this.offset = (await this.$rest.get(`file/offset?uploadId=${this.upload._id}`)).data.offset;
     return this._sendChunks();
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  beforeUpload() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  afterUpload() {}
 }

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -31,7 +31,6 @@ export default class Upload {
   async _sendChunks() {
     const onUploadProgress = e => this.progress({
       current: this.offset + e.loaded,
-      total: this.file.size,
       indeterminate: !e.lengthComputable,
     });
 


### PR DESCRIPTION
This PR contains some maintenance changes, make all callback optional except the start() method, and make sure progress updates when the callback is not called. 

This PR also add back removed callbacks because the callback was applied before and after all files and can be easily used on consuming component (instead of inside uploader). 