### PR TITLE
Adds draggability flag

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -15,6 +15,7 @@ v-app.app
           v-card-actions
             v-layout(column)
               v-checkbox.mt-2(hide-details, label="Select", v-model="selectEnabled")
+              v-checkbox.mt-1(hide-details, label="Draggable", v-model="dragEnabled")
               v-checkbox.mt-1(hide-details, label="New Folder", v-model="newFolderEnabled")
               v-checkbox.mt-1(hide-details, label="Upload", v-model="newItemEnabled")
               v-checkbox.mt-1.mb-1(hide-details, label="Search Box", v-model="searchEnabled")
@@ -50,6 +51,7 @@ v-app.app
               v-if="location",
               :location.sync="location",
               :select-enabled="selectEnabled",
+              :draggable="dragEnabled",
               :new-item-enabled="newItemEnabled",
               :new-folder-enabled="newFolderEnabled",
               @click:newitem="uploader = true",
@@ -84,6 +86,7 @@ export default {
       uiOptionsMenu: false,
       browserLocation: null,
       forgotPasswordUrl: '/#?dialog=resetpassword',
+      dragEnabled: false,
       selectEnabled: true,
       newItemEnabled: true,
       newFolderEnabled: true,

--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -13,6 +13,10 @@ export default {
   },
   mixins: [sizeFormatter],
   props: {
+    draggable: {
+      type: Boolean,
+      default: false,
+    },
     location: {
       type: Object,
       required: true,
@@ -168,12 +172,17 @@ export default {
 <template lang="pug">
 girder-data-table.girder-file-browser(
     v-model="selected",
+    :draggable="draggable",
     :rows="rows",
     :pagination.sync="pagination",
     :total-items="totalItems",
     :loading="loading",
     :select-enabled="selectEnabled",
-    @rowclick="changeLocation")
+    @rowclick="changeLocation",
+    @drag="$emit('drag', $event)",
+    @dragstart="$emit('dragstart', $event)",
+    @dragend="$emit('dragend', $event)",
+    @drop="$emit('drop', $event)")
 
   template(slot="header", slot-scope="props")
     tr.secondary.lighten-5

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -71,10 +71,10 @@ v-data-table.girder-data-table(
   template(slot="items", slot-scope="props")
     tr.itemRow(:draggable="draggable", :active="props.selected",
         @click="handleRowSelect($event, props)",
-        @drag="$emit('drag', { props, event: $event })",
-        @dragstart="$emit('dragstart', { props, event: $event })",
-        @dragend="$emit('dragend', { props, event: $event })",
-        @drop="$emit('drop', { props, event: $event })",
+        @drag="$emit('drag', { items: [props], event: $event })",
+        @dragstart="$emit('dragstart', { items: [props], event: $event })",
+        @dragend="$emit('dragend', { items: [props], event: $event })",
+        @drop="$emit('drop', { items: [props], event: $event })",
         :key="props.index")
       td.pl-3.pr-0(v-if="selectEnabled")
         v-checkbox.secondary--text.text--darken-1.pr-2(

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -1,29 +1,33 @@
 <script>
 export default {
   props: {
-    rows: {
-      type: Array,
+    draggable: {
+      type: Boolean,
+      default: false,
+    },
+    loading: {
+      type: Boolean,
       required: true,
     },
     pagination: {
       type: Object,
       required: true,
     },
-    totalItems: {
-      type: Number,
+    rows: {
+      type: Array,
       required: true,
     },
-    loading: {
+    selectEnabled: {
       type: Boolean,
+      required: true,
+    },
+    totalItems: {
+      type: Number,
       required: true,
     },
     value: {
       type: Array,
       default: () => [],
-    },
-    selectEnabled: {
-      type: Boolean,
-      required: true,
     },
   },
   data() {
@@ -65,8 +69,12 @@ v-data-table.girder-data-table(
         :headers="props.headers")
 
   template(slot="items", slot-scope="props")
-    tr.itemRow(:active="props.selected",
+    tr.itemRow(:draggable="draggable", :active="props.selected",
         @click="handleRowSelect($event, props)",
+        @drag="$emit('drag', { props, event: $event })",
+        @dragstart="$emit('dragstart', { props, event: $event })",
+        @dragend="$emit('dragend', { props, event: $event })",
+        @drop="$emit('drop', { props, event: $event })",
         :key="props.index")
       td.pl-3.pr-0(v-if="selectEnabled")
         v-checkbox.secondary--text.text--darken-1.pr-2(


### PR DESCRIPTION
This feature was requested by @zackgalbreath and was pretty trivial to implement.

* Add dragability for rows in DataTable.vue
* Upstream is expected to register and use these rows with some dropzone.
* New events:  DataBrowser and DataTable both emit:
  * drag
  * drop
  * dragstart
  * dragend
* New props:
  * DataBrowser gets `draggable: Boolean`
  * DataTable gets `draggable: Boolean`

Those event payloads are structured `{ items: Array<{ index, item, selected }>, event: <native event> }` .

@zackgalbreath will this suit your use case?  I actually really like this as a feature and I may be able to use it myself soon.