### PR TITLE
Import Vuetify as a module, reducing size

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ yarn add @girder/components
 [VueCLI](https://cli.vuejs.org/) is required for building applications with Girder web components.
 However, a few additional packages must still be manually installed:
 ```bash
-npm install -D sass-loader node-sass pug-plain-loader pug
+npm install -D sass-loader node-sass pug-plain-loader pug stylus-loader stylus vue-cli-plugin-vuetify vuetify-loader
 # or
-yarn add -D sass-loader node-sass pug-plain-loader pug
+yarn add -D sass-loader node-sass pug-plain-loader pug stylus-loader stylus vue-cli-plugin-vuetify vuetify-loader
 ```
 
 ### Initialization

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "qs": "^6.5.2",
     "vue": "^2.5.21",
     "vue-async-computed": "^3.4.1",
-    "vuetify": "^1.3.15"
+    "vue-cli-plugin-vuetify": "^0.5.0",
+    "vuetify": "^1.3.15",
+    "vuetify-loader": "^1.2.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.0.0",
@@ -37,6 +39,8 @@
     "sass-loader": "^7.0.1",
     "stylelint": "^9.6.0",
     "stylelint-config-standard": "^18.2.0",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^3.0.2",
     "vue-cli-plugin-pug": "^1.0.7",
     "vue-template-compiler": "^2.5.16"
   },
@@ -80,7 +84,9 @@
     },
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1",
-      "\\.css$": "<rootDir>/tests/mocks/stub.js"
+      "\\.css$": "<rootDir>/tests/mocks/stub.js",
+      "^vuetify/lib$": "vuetify",
+      "^vuetify/lib/(.*)": "vuetify/es5/$1"
     },
     "snapshotSerializers": [
       "jest-serializer-vue"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import VueAsyncComputed from 'vue-async-computed';
-import Vuetify from 'vuetify';
+import Vuetify from 'vuetify/lib';
 import * as components from './components';
 import * as constants from './constants';
 import RestClient from './rest';

--- a/src/utils/vuetifyConfig.js
+++ b/src/utils/vuetifyConfig.js
@@ -4,7 +4,7 @@
  * installing the GirderVue plugin.
  */
 
-import colors from 'vuetify/es5/util/colors';
+import colors from 'vuetify/lib/util/colors';
 
 export default {
   theme: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,6 +2687,11 @@ css-loader@^1.0.1:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
+css-parse@1.7.x:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-1.7.0.tgz#321f6cf73782a6ff751111390fc05e2c657d8c9b"
+  integrity sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=
+
 css-select-base-adapter@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
@@ -2880,6 +2885,12 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
 
+debug@*, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  dependencies:
+    ms "^2.1.1"
+
 debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2895,12 +2906,6 @@ debug@=3.1.0:
 debug@^3.1.0, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   dependencies:
     ms "^2.1.1"
 
@@ -4285,6 +4290,18 @@ glob-parent@^3.1.0:
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
+glob@7.0.x:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  integrity sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
   version "7.1.3"
@@ -6020,7 +6037,7 @@ lodash.bind@^4.1.4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
 
-lodash.clonedeep@^4.3.2:
+lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
@@ -8522,6 +8539,11 @@ sass-loader@^7.0.1:
     pify "^3.0.0"
     semver "^5.5.0"
 
+sax@0.5.x:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
+  integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
+
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -8811,6 +8833,13 @@ source-map-support@~0.5.6:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+
+source-map@0.1.x:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.2:
   version "0.4.4"
@@ -9172,6 +9201,27 @@ stylelint@^9.6.0:
     sugarss "^2.0.0"
     svg-tags "^1.0.0"
     table "^5.0.0"
+
+stylus-loader@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stylus-loader/-/stylus-loader-3.0.2.tgz#27a706420b05a38e038e7cacb153578d450513c6"
+  integrity sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==
+  dependencies:
+    loader-utils "^1.0.2"
+    lodash.clonedeep "^4.5.0"
+    when "~3.6.x"
+
+stylus@^0.54.5:
+  version "0.54.5"
+  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.5.tgz#42b9560931ca7090ce8515a798ba9e6aa3d6dc79"
+  integrity sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=
+  dependencies:
+    css-parse "1.7.x"
+    debug "*"
+    glob "7.0.x"
+    mkdirp "0.5.x"
+    sax "0.5.x"
+    source-map "0.1.x"
 
 sugarss@^2.0.0:
   version "2.0.0"
@@ -9818,6 +9868,11 @@ vue-cli-plugin-pug@^1.0.7:
     pug-plain-loader "^1.0.0"
     raw-loader "^0.5.1"
 
+vue-cli-plugin-vuetify@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-0.5.0.tgz#14c9a61884da58cf6aaf8ff3309044931907f184"
+  integrity sha512-TigfiZUs7SN3Z6uxKilqJUtYxte8vp0F4QxabCli6hkKPqU97JzAZc3P7AL6omkRAd2DMI26fOrIGjuALTvXww==
+
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
@@ -9879,6 +9934,13 @@ vue-template-es2015-compiler@^1.6.0:
 vue@^2.5.21:
   version "2.5.22"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.22.tgz#3bf88041af08b8539c37b268b70ca79245e9cc30"
+
+vuetify-loader@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/vuetify-loader/-/vuetify-loader-1.2.1.tgz#7b4724d9566ad4c400dec69d0192b83af0924c63"
+  integrity sha512-p4WEVvWt6/5Xm5H8A4ESzWlheAbPbQAhojhcpf9SnOIH9894mBmU4l7asuD7xZ2E/MTl1BeX3ZZj2hrv7/NIxQ==
+  dependencies:
+    loader-utils "^1.1.0"
 
 vuetify@^1.3.15:
   version "1.3.15"
@@ -10086,6 +10148,11 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+when@~3.6.x:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.6.4.tgz#473b517ec159e2b85005497a13983f095412e34e"
+  integrity sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
See: https://vuetifyjs.com/en/framework/a-la-carte#importing-components

Since this allows Webpack's tree-shaking to occur, this reduces the size of the resulting UMD library and demo app by ~40%.

Here's the specific results of applying this change:
Before: `build`
```
  File                      Size                     Gzipped

  dist/girder.umd.min.js    645.97 KiB               159.85 KiB
  dist/girder.umd.js        1490.58 KiB              284.00 KiB
  dist/girder.common.js     1490.12 KiB              283.83 KiB
  dist/girder.css           358.94 KiB               53.17 KiB
```

Before: `build:demo`
```
  File                                    Size              Gzipped

  _site/js/chunk-vendors.09a74c68.js      657.34 KiB        168.95 KiB
  _site/js/app.340b2dbd.js                56.74 KiB         14.27 KiB
  _site/css/chunk-vendors.82369c17.css    355.21 KiB        52.33 KiB
  _site/css/app.1ea9639a.css              3.82 KiB          1.17 KiB
```

After: `build`
```
  File                      Size                     Gzipped

  dist/girder.umd.min.js    368.81 KiB               113.88 KiB
  dist/girder.umd.js        948.40 KiB               222.27 KiB
  dist/girder.common.js     947.93 KiB               222.08 KiB
  dist/girder.css           395.72 KiB               59.05 KiB
```

After: `build:demo`
```
  File                                    Size              Gzipped

  _site/js/chunk-vendors.0ad10a31.js      404.42 KiB        131.42 KiB
  _site/js/app.1f8e3ccb.js                59.07 KiB         15.02 KiB
  _site/css/chunk-vendors.ca28d749.css    392.14 KiB        58.31 KiB
  _site/css/app.1ea9639a.css              3.82 KiB          1.17 KiB
```