### PR TITLE
Upload class optional members

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -53,6 +53,14 @@ export default {
       default: true,
       type: Boolean,
     },
+    preUpload: {
+      default: () => {},
+      type: Function,
+    },
+    postUpload: {
+      default: () => {},
+      type: Function,
+    },
     uploadCls: {
       default: Upload,
       type: Function,
@@ -113,7 +121,7 @@ export default {
       const results = [];
       this.uploading = true;
       this.errorMessage = null;
-
+      await this.preUpload();
       for (let i = 0; i < this.files.length; i += 1) {
         const file = this.files[i];
         if (file.status === 'done') {
@@ -180,6 +188,7 @@ export default {
           }
         }
       }
+      await this.postUpload();
       this.uploading = false;
       this.files = [];
       this.$emit('done', results);

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -111,6 +111,7 @@ export default {
         progress: {
           indeterminate: false,
           current: 0,
+          size: file.size,
         },
         upload: null,
         result: null,

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -145,29 +145,19 @@ export default {
                 progress,
               });
               // eslint-disable-next-line no-await-in-loop
-              await file.upload.beforeUpload({
-                current: i,
-                total: this.files.length,
-              });
+              await file.upload.beforeUpload();
               // eslint-disable-next-line no-await-in-loop
               file.result = await file.upload.start();
             }
             // eslint-disable-next-line no-await-in-loop
-            await file.upload.afterUpload({
-              current: i,
-              total: this.files.length,
-            });
+            await file.upload.afterUpload();
             delete file.upload;
             results.push(file.result);
             file.status = 'done';
             file.progress.current = file.file.size;
           } catch (error) {
             // eslint-disable-next-line no-await-in-loop
-            await file.upload.onError({
-              error,
-              current: i,
-              total: this.files.length,
-            });
+            await file.upload.onError(error);
 
             if (error.response) {
               this.errorMessage = error.response.data.message || 'An error occurred during upload.';

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -136,7 +136,7 @@ export default {
           try {
             if (file.upload) {
               // eslint-disable-next-line no-await-in-loop
-              file.result = await (file.upload.resume ? file.upload.resume() : file.upload.start());
+              file.result = await file.upload.resume();
             } else {
               // eslint-disable-next-line new-cap
               file.upload = new this.uploadCls(file.file, {
@@ -144,37 +144,30 @@ export default {
                 parent: this.dest,
                 progress,
               });
-              if (file.upload.beforeUpload) {
-                // eslint-disable-next-line no-await-in-loop
-                await file.upload.beforeUpload({
-                  current: i,
-                  total: this.files.length,
-                });
-              }
-
               // eslint-disable-next-line no-await-in-loop
-              file.result = await file.upload.start();
-            }
-            if (file.upload.afterUpload) {
-              // eslint-disable-next-line no-await-in-loop
-              await file.upload.afterUpload({
+              await file.upload.beforeUpload({
                 current: i,
                 total: this.files.length,
               });
+              // eslint-disable-next-line no-await-in-loop
+              file.result = await file.upload.start();
             }
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.afterUpload({
+              current: i,
+              total: this.files.length,
+            });
             delete file.upload;
             results.push(file.result);
             file.status = 'done';
             file.progress.current = file.file.size;
           } catch (error) {
-            if (file.upload.onError) {
-              // eslint-disable-next-line no-await-in-loop
-              await file.upload.onError({
-                error,
-                current: i,
-                total: this.files.length,
-              });
-            }
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.onError({
+              error,
+              current: i,
+              total: this.files.length,
+            });
 
             if (error.response) {
               this.errorMessage = error.response.data.message || 'An error occurred during upload.';

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -124,10 +124,11 @@ export default {
             Object.assign(file.progress, event);
           };
           file.status = 'uploading';
+          file.progress.indeterminate = true;
           try {
             if (file.upload) {
               // eslint-disable-next-line no-await-in-loop
-              file.result = await file.upload.resume();
+              file.result = await (file.upload.resume ? file.upload.resume() : file.upload.start());
             } else {
               // eslint-disable-next-line new-cap
               file.upload = new this.uploadCls(file.file, {
@@ -135,29 +136,37 @@ export default {
                 parent: this.dest,
                 progress,
               });
-              // eslint-disable-next-line no-await-in-loop
-              await file.upload.beforeUpload({
-                current: i,
-                total: this.files.length,
-              });
+              if (file.upload.beforeUpload) {
+                // eslint-disable-next-line no-await-in-loop
+                await file.upload.beforeUpload({
+                  current: i,
+                  total: this.files.length,
+                });
+              }
+
               // eslint-disable-next-line no-await-in-loop
               file.result = await file.upload.start();
             }
-            // eslint-disable-next-line no-await-in-loop
-            await file.upload.afterUpload({
-              current: i,
-              total: this.files.length,
-            });
+            if (file.upload.afterUpload) {
+              // eslint-disable-next-line no-await-in-loop
+              await file.upload.afterUpload({
+                current: i,
+                total: this.files.length,
+              });
+            }
             delete file.upload;
             results.push(file.result);
             file.status = 'done';
+            file.progress.current = file.file.size;
           } catch (error) {
-            // eslint-disable-next-line no-await-in-loop
-            await file.upload.onError({
-              error,
-              current: i,
-              total: this.files.length,
-            });
+            if (file.upload.onError) {
+              // eslint-disable-next-line no-await-in-loop
+              await file.upload.onError({
+                error,
+                current: i,
+                total: this.files.length,
+              });
+            }
 
             if (error.response) {
               this.errorMessage = error.response.data.message || 'An error occurred during upload.';

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -83,7 +83,7 @@ export default {
       return `${this.files.length} selected (${this.formatSize(this.totalSize)} total)`;
     },
     totalProgress() {
-      return this.files.reduce((v, f) => v + (f.progress.current || 0), 0);
+      return this.files.reduce((v, f) => v + (f.progress.current), 0);
     },
     totalSize() {
       return this.files.reduce((v, f) => v + f.file.size, 0);
@@ -100,7 +100,10 @@ export default {
       this.files = files.map(file => ({
         file,
         status: 'pending',
-        progress: {},
+        progress: {
+          indeterminate: false,
+          current: 0,
+        },
         upload: null,
         result: null,
       }));
@@ -118,7 +121,7 @@ export default {
           results.push(file.result);
         } else {
           const progress = (event) => {
-            file.progress = Object.assign({}, file.progress, event);
+            Object.assign(file.progress, event);
           };
           file.status = 'uploading';
           try {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import * as utils from './utils';
 /**
  * This installs the Vue plugin for this library. This is exported in the top level module,
  * making it a Vue plugin.
- * @param Vue the Vue prototype to install the plugin into.
+ * @param {Object} Vue the Vue prototype to install the plugin into.
  */
 function install(Vue) {
   Vue.use(Vuetify, utils.vuetifyConfig);

--- a/src/utils/UploadBase.js
+++ b/src/utils/UploadBase.js
@@ -1,0 +1,75 @@
+export default class UploadBase {
+  /**
+   * The abstract base class of a single file uploader.
+   * @abstract
+   * @param file {File | Blob} the file to upload
+   * @param opts {Object} upload options.
+   * @param opts.$rest {Object} an axios instance used for communicating with Girder.
+   * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
+   * @param opts.progress {Function} A progress callback for the upload. It can take an Object
+   *   argument with either ``"indeterminate": true``, or numeric ``current`` fields.
+   */
+  constructor(
+    file,
+    {
+      $rest,
+      parent,
+      progress = () => null,
+    } = {},
+  ) {
+    Object.assign(this, {
+      $rest,
+      file,
+      parent,
+      progress,
+      upload: null,
+      offset: 0,
+      behavior: null,
+    });
+  }
+
+  /**
+   * Start the upload. The returned Promise will be resolved with the Girder file that was created
+   * or rejected with an ``Error`` that has ``config``, ``request``, and ``response`` properties.
+   * @abstract
+   */
+  async start() { // eslint-disable-line class-methods-use-this
+    throw new Error('not implemented');
+  }
+
+  /**
+   * If an error has been encountered, when user clicks the Resume button,
+   * this ``resume()`` will be called. The simplest implementation is to call ``start()`` directly.
+   */
+  async resume() {
+    return this.start();
+  }
+
+  /**
+   * This callback is called before the upload is started. This callback is asynchronous.
+   * If it returns a Promise, the caller will await its resolution before continuing.
+   * @param current {Number} The index of this file in the list of files being uploaded.
+   * @param total {Number} The total number of files being uploaded.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  beforeUpload({ current, total }) {}
+
+  /**
+   * This callback is called after the upload is completed. This callback is asynchronous.
+   * If it returns a Promise, the caller will await its resolution before continuing.
+   * @param current {Number} The index of this file in the list of files being uploaded.
+   * @param total {Number} The total number of files being uploaded.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  afterUpload({ current, total }) {}
+
+  /**
+   * This callback is called if an error occurs during the upload. This callback is asynchronous.
+   * If it returns a Promise, the caller will await its resolution before continuing.
+   * @param error {Exception} The exception object.
+   * @param current {Number} The index of this file in the list of files being uploaded.
+   * @param total {Number} The total number of files being uploaded.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  onError({ error, current, total }) {}
+}

--- a/src/utils/UploadBase.js
+++ b/src/utils/UploadBase.js
@@ -22,9 +22,6 @@ export default class UploadBase {
       file,
       parent,
       progress,
-      upload: null,
-      offset: 0,
-      behavior: null,
     });
   }
 
@@ -48,28 +45,22 @@ export default class UploadBase {
   /**
    * This callback is called before the upload is started. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
-   * @param current {Number} The index of this file in the list of files being uploaded.
-   * @param total {Number} The total number of files being uploaded.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  beforeUpload({ current, total }) {}
+  beforeUpload() {}
 
   /**
    * This callback is called after the upload is completed. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
-   * @param current {Number} The index of this file in the list of files being uploaded.
-   * @param total {Number} The total number of files being uploaded.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  afterUpload({ current, total }) {}
+  afterUpload() {}
 
   /**
    * This callback is called if an error occurs during the upload. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
    * @param error {Exception} The exception object.
-   * @param current {Number} The index of this file in the list of files being uploaded.
-   * @param total {Number} The total number of files being uploaded.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  onError({ error, current, total }) {}
+  onError(error) {}
 }

--- a/src/utils/UploadBase.js
+++ b/src/utils/UploadBase.js
@@ -2,11 +2,11 @@ export default class UploadBase {
   /**
    * The abstract base class of a single file uploader.
    * @abstract
-   * @param file {File | Blob} the file to upload
-   * @param opts {Object} upload options.
-   * @param opts.$rest {Object} an axios instance used for communicating with Girder.
-   * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
-   * @param opts.progress {Function} A progress callback for the upload. It can take an Object
+   * @param {File | Blob} file the file to upload
+   * @param {Object} opts upload options.
+   * @param {Object} opts.$rest an axios instance used for communicating with Girder.
+   * @param {Object} opts.parent upload destination. Must have ``_id`` and ``_modelType``.
+   * @param {Function} opts.progress A progress callback for the upload. It can take an Object
    *   argument with either ``"indeterminate": true``, or numeric ``current`` and ``size`` fields.
    */
   constructor(
@@ -59,7 +59,7 @@ export default class UploadBase {
   /**
    * This callback is called if an error occurs during the upload. This callback is asynchronous.
    * If it returns a Promise, the caller will await its resolution before continuing.
-   * @param error {Exception} The exception object.
+   * @param {Exception} error The exception object.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
   onError(error) {}

--- a/src/utils/UploadBase.js
+++ b/src/utils/UploadBase.js
@@ -7,7 +7,7 @@ export default class UploadBase {
    * @param opts.$rest {Object} an axios instance used for communicating with Girder.
    * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
    * @param opts.progress {Function} A progress callback for the upload. It can take an Object
-   *   argument with either ``"indeterminate": true``, or numeric ``current`` fields.
+   *   argument with either ``"indeterminate": true``, or numeric ``current`` and ``size`` fields.
    */
   constructor(
     file,

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -9,14 +9,14 @@ const uploadBehaviors = { s3: S3Upload };
 export default class Upload extends UploadBase {
   /**
    * Represents an upload of a single file to the server.
-   * @param file {File | Blob} the file to upload
-   * @param opts {Object} upload options.
-   * @param opts.$rest {Object} an axios instance used for communicating with Girder.
-   * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
-   * @param opts.progress {Function} A progress callback for the upload. It can take an Object
+   * @param {File | Blob} file the file to upload
+   * @param {Object} opts upload options.
+   * @param {Object} opts.$rest an axios instance used for communicating with Girder.
+   * @param {Object} opts.parent upload destination. Must have ``_id`` and ``_modelType``.
+   * @param {Function} opts.progress A progress callback for the upload. It can take an Object
    *   argument with either ``"indeterminate": true``, or numeric ``current`` and ``size`` fields.
-   * @param opts.params {Object} Additional parameters to pass on the upload init request.
-   * @param opts.chunkLen {Number} Chunk size for sending the file (integer number of bytes).
+   * @param {Object} opts.params Additional parameters to pass on the upload init request.
+   * @param {Number} opts.chunkLen Chunk size for sending the file (integer number of bytes).
    */
   constructor(file, {
     $rest,

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -14,7 +14,7 @@ export default class Upload extends UploadBase {
    * @param opts.$rest {Object} an axios instance used for communicating with Girder.
    * @param opts.parent {Object} upload destination. Must have ``_id`` and ``_modelType``.
    * @param opts.progress {Function} A progress callback for the upload. It can take an Object
-   *   argument with either ``"indeterminate": true``, or numeric ``current`` fields.
+   *   argument with either ``"indeterminate": true``, or numeric ``current`` and ``size`` fields.
    * @param opts.params {Object} Additional parameters to pass on the upload init request.
    * @param opts.chunkLen {Number} Chunk size for sending the file (integer number of bytes).
    */
@@ -35,8 +35,9 @@ export default class Upload extends UploadBase {
 
   async _sendChunks() {
     const onUploadProgress = e => this.progress({
-      current: this.offset + e.loaded,
       indeterminate: !e.lengthComputable,
+      current: this.offset + e.loaded,
+      size: this.file.size,
     });
 
     while (this.offset < this.file.size) {

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -54,7 +54,6 @@ export default class Upload extends UploadBase {
   }
 
   async start() {
-    this.progress({ indeterminate: true });
     this.upload = (await this.$rest.post('/file', stringify({
       parentType: this.parent._modelType,
       parentId: this.parent._id,

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -31,7 +31,6 @@ export default class Upload {
   async _sendChunks() {
     const onUploadProgress = e => this.progress({
       current: this.offset + e.loaded,
-      total: this.file.size,
       indeterminate: !e.lengthComputable,
     });
 


### PR DESCRIPTION
This PR includes a few improvements.

* Add back `preUpload`, `postUpload` callbacks. Because (1) The demo app is using these callback, the demo app is broken and won't refresh the file list after upload at this moment. (2) The context of these callbacks is the parent Vue component of Upload.vue. the context `afterUpload`, and `beforeUpload` is the upload class. Without hacking, It's way easier to consume the callback in the parent component with these callbacks. (3) `afterUpload`, and `beforeUpload` is for the individual file. `preUpload`, `postUpload` is for all of the uploads. Take the demo app as an example. It's meant to refresh after the whole upload process. Again, without hacking, these are easier to work with. 

* This line https://github.com/girder/girder_web_components/compare/upload_class_optional_members?expand=1#diff-82311ba10aa7e62082a059e895af2774R168 make progress bar progress if the custom uploader doesn't report progress. 
![image](https://user-images.githubusercontent.com/3123478/55984814-555ea480-5c6c-11e9-91cc-ebd7fff26329.png)

* This line https://github.com/girder/girder_web_components/compare/upload_class_optional_members?expand=1#diff-82311ba10aa7e62082a059e895af2774R135 make it show loading state if the custom uploader doesn't report its uploading. Same image above.

* https://github.com/girder/girder_web_components/compare/upload_class_optional_members?expand=1#diff-82311ba10aa7e62082a059e895af2774R112 and next line make the property responsive, so it's easier to work with when changing their values. (No need to use Object.assign({}, existing) to change the object all together) These also let people know what properties are valid beforehand without tracing the code. 

* https://github.com/girder/girder_web_components/compare/upload_class_optional_members?expand=1#diff-8af87c0ce07db8082e10e648f84bda61L34 is not used

* By adding the conditionals, the custom uploaders literally only need to provide start(), Otherwise, a custom uploader needs to provide all the callbacks itself or subclass upload.js, either way, it also needs to provide a resume(), even if the resume() simply calls start(). If we don't like the conditional, we should provide an 'abstract class' that a custom upload should inherit from. 

I find these improvements are useful because I have an app that uploads numerous text files, which is 1, doesn't go to upload endpoint (calls a custom endpoint) 2, small but many, so no need to report individual process, but need overall progress. and if failed due to a network issue, no need to resume() and just start from the beginning. 