### PR TITLE
Internalize helper variable

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -2,8 +2,6 @@
 <script>
 import { DebounceCounter } from '../utils';
 
-const counter = new DebounceCounter();
-
 export default {
   props: {
     maxQuickResults: {
@@ -26,7 +24,7 @@ export default {
   },
   computed: {
     loading() {
-      return counter.flag;
+      return this.counter.flag;
     },
     quickResults() {
       return this.searchResults.slice(0, this.maxQuickResults);
@@ -46,7 +44,7 @@ export default {
       default: [],
       async get() {
         let results = [];
-        counter.inc();
+        this.counter.inc();
         try {
           if (this.searchText) {
             const { data } = await this.girderRest.get('resource/search', {
@@ -57,10 +55,13 @@ export default {
         } catch (err) {
           this.$emit('error', err.message || 'Unknown error during search');
         }
-        counter.dec();
+        this.counter.dec();
         return results;
       },
     },
+  },
+  beforeCreate() {
+    this.counter = new DebounceCounter();
   },
   methods: {
     formatUsername(user) {


### PR DESCRIPTION
This PR internalize the DebounceCounter helper variable to an individual instance of the Search component. Even though I don't see we could run into issues in a short time with the current implementation, but this change prevents potential weird behavior and anti-pattern and help me monkey patch this Search in a downstream application.