### PR TITLE
Drag example

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -57,7 +57,14 @@ v-app.app
               :new-folder-enabled="newFolderEnabled",
               @click:newitem="uploader = true",
               @click:newfolder="newFolder = true",
-              @selection-changed="selected = $event")
+              @selection-changed="selected = $event",
+              @dragend="dragend")
+        v-card.mt-3(v-if="dragEnabled", @dragenter="prev", @dragover="prev", @drop="drop")
+          v-card-title
+            h3.headline Drop Zone
+          v-card-text
+            p(v-if="!(dropped.length)") Drag a row here to see results
+            p(v-else, v-for="drop in dropped") {{ drop.item._modelType }} {{ drop.item.name }} {{ drop.item.size }} 
 </template>
 
 <script>
@@ -87,12 +94,13 @@ export default {
       uiOptionsMenu: false,
       browserLocation: null,
       forgotPasswordUrl: '/#?dialog=resetpassword',
-      dragEnabled: false,
+      dragEnabled: true,
       selectEnabled: true,
       newItemEnabled: true,
       newFolderEnabled: true,
       searchEnabled: true,
       selected: [],
+      dropped: [],
     };
   },
   asyncComputed: {
@@ -141,6 +149,16 @@ export default {
     },
   },
   methods: {
+    prev(event) {
+      event.preventDefault();
+    },
+    dragend({ items, event }) {
+      this.dropped = items;
+    },
+    drop(event) {
+      const identifiers = event.dataTransfer.getData('application/x-girder-items');
+      console.log(identifiers);
+    },
     postUpload() {
       // postUpload is an example of using hooks for greater control of component behavior.
       // here, we can complete the dialog disappear animation before the upload UI resets.

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -64,7 +64,8 @@ v-app.app
             h3.headline Drop Zone
           v-card-text
             p(v-if="!(dropped.length)") Drag a row here to see results
-            p(v-else, v-for="drop in dropped") {{ drop.item._modelType }} {{ drop.item.name }} {{ drop.item.size }} 
+            p(v-else, v-for="drop in dropped")
+              | {{ drop.item._modelType }} {{ drop.item.name }} {{ drop.item.size }}
 </template>
 
 <script>
@@ -101,6 +102,7 @@ export default {
       searchEnabled: true,
       selected: [],
       dropped: [],
+      droppedIDs: [],
     };
   },
   asyncComputed: {
@@ -152,12 +154,11 @@ export default {
     prev(event) {
       event.preventDefault();
     },
-    dragend({ items, event }) {
+    dragend({ items }) {
       this.dropped = items;
     },
     drop(event) {
-      const identifiers = event.dataTransfer.getData('application/x-girder-items');
-      console.log(identifiers);
+      this.droppedIDs = event.dataTransfer.getData('application/x-girder-items');
     },
     postUpload() {
       // postUpload is an example of using hooks for greater control of component behavior.

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -49,6 +49,11 @@ export default {
         this.$emit('rowclick', props.item);
       }
     },
+    emitDrag(eventname, event, items) {
+      const idStrings = JSON.stringify(items.map(i => i.item._id));
+      event.dataTransfer.setData('application/x-girder-items', idStrings);
+      this.$emit(eventname, { event, items });
+    },
   },
 };
 </script>
@@ -76,10 +81,9 @@ v-data-table.girder-data-table(
     tr.itemRow(:draggable="draggable", :active="props.selected",
         :class="{ selectable: !selectEnabled }",
         @click="handleRowSelect($event, props)",
-        @drag="$emit('drag', { items: [props], event: $event })",
-        @dragstart="$emit('dragstart', { items: [props], event: $event })",
-        @dragend="$emit('dragend', { items: [props], event: $event })",
-        @drop="$emit('drop', { items: [props], event: $event })",
+        @drag="emitDrag('drag', $event, [props])",
+        @dragstart="emitDrag('dragstart', $event, [props])",
+        @dragend="emitDrag('dragend', $event, [props])",
         :key="props.index")
       td.pl-3.pr-0(v-if="selectEnabled")
         v-checkbox.secondary--text.text--darken-1.pr-2(


### PR DESCRIPTION
For @zackgalbreath 

Note that `dragend()` is introduced in this PR, so that handler won't work.

This PR adds `application/x-girder-items` data to `DragEvent.dataTransfer`.  If your app just has 1 dropzone, you can listen to `dragend` and get the full js object list of items dragged, but if you have > 1 dropzone, that event fires from the source, so it's not possible to determine what the destination target was and you have to listen to the actual `drop` event, and there's no way to get a javascript object from source to destination event.

You can, however, pass strings.  I think I'll have to add `_modelType` to the JSON serialized string, which is a little gross, but would make the drop event contain all the data you might need to fetch that item/folder/whatever from girder.