### PR TITLE
Migrate Job listing components from other repo

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -19,6 +19,10 @@ v-app.app
               v-checkbox.mt-1(hide-details, label="New Folder", v-model="newFolderEnabled")
               v-checkbox.mt-1(hide-details, label="Upload", v-model="newItemEnabled")
               v-checkbox.mt-1.mb-1(hide-details, label="Search Box", v-model="searchEnabled")
+              v-divider
+              v-list(dense)
+                v-list-tile(@click="jobDialog=!jobDialog")
+                  v-list-tile-title Jobs
     v-spacer
     girder-search(v-if="searchEnabled", @select="handleSearchSelect")
     v-btn(flat, icon, @click="girderRest.logout()")
@@ -57,6 +61,8 @@ v-app.app
               @click:newitem="uploader = true",
               @click:newfolder="newFolder = true",
               @selection-changed="selected = $event")
+  v-dialog(v-model="jobDialog", full-width)
+    girder-job-list
 </template>
 
 <script>
@@ -67,6 +73,7 @@ import {
   Upload as GirderUpload,
   UpsertFolder as GirderUpsertFolder,
 } from '@/components';
+import { JobList as GirderJobList } from '@/components/job';
 import { createLocationValidator } from '@/utils';
 
 export default {
@@ -78,6 +85,7 @@ export default {
     GirderSearch,
     GirderUpload,
     GirderUpsertFolder,
+    GirderJobList,
   },
   data() {
     return {
@@ -93,6 +101,7 @@ export default {
       newFolderEnabled: true,
       searchEnabled: true,
       selected: [],
+      jobDialog: false,
     };
   },
   asyncComputed: {

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import Girder from '@';
+import NotificationBus from '@/utils/notifications';
 import RestClient from '@/rest';
+
 import App from './App.vue';
 
 Vue.use(Girder);
@@ -8,9 +10,12 @@ const girderRest = new RestClient({
   apiRoot: process.env.VUE_APP_API_ROOT,
 });
 
+const notificationBus = new NotificationBus(girderRest);
+notificationBus.connect();
+
 girderRest.fetchUser().then(() => {
   new Vue({
     render: h => h(App),
-    provide: { girderRest },
+    provide: { girderRest, notificationBus },
   }).$mount('#app');
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.18.0",
     "js-cookie": "^2.2.0",
     "markdown-it": "^8.4.2",
+    "moment": "^2.24.0",
     "qs": "^6.5.2",
     "vue": "^2.5.21",
     "vue-async-computed": "^3.4.1",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,6 +3,7 @@ import 'vuetify/dist/vuetify.min.css';
 
 import Authentication from './Authentication/';
 import DataBrowser from './DataBrowser.vue';
+import job from './job';
 import Markdown from './Markdown.vue';
 import MarkdownEditor from './MarkdownEditor.vue';
 import Search from './Search.vue';
@@ -12,6 +13,7 @@ import UpsertFolder from './UpsertFolder.vue';
 export {
   Authentication,
   DataBrowser,
+  job,
   Markdown,
   MarkdownEditor,
   Search,

--- a/src/components/job/FilterForm.vue
+++ b/src/components/job/FilterForm.vue
@@ -1,0 +1,86 @@
+<script>
+import * as status from './status';
+
+export default {
+  props: {
+    jobType: {
+      type: [String, Object],
+      default: null,
+    },
+    jobTypeList: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+    status: {
+      type: [Number, Object],
+      default: null,
+    },
+    statusList: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+  },
+  data() {
+    return {
+      fromDateMenu: false,
+      toDateMenu: false,
+    };
+  },
+  computed: {
+    statusItemList() {
+      return this.statusList
+        .map(status.getByValue)
+        .filter(s => s && s.text)
+        .sort((a, b) => {
+          if (a.text > b.text) {
+            return 1;
+          } else if (a.text < b.text) {
+            return -1;
+          }
+          return 0;
+        });
+    },
+  },
+};
+</script>
+
+<template lang="pug">
+v-card.job-filter(dark, color="primary darken-1")
+  v-container.py-2(fluid, grid-list-lg)
+    v-layout(row)
+      v-flex(sm12, d-flex)
+        h3.primary--text.text--lighten-2 Jobs
+    v-layout(row, justify-center)
+      v-flex(sm3, d-flex)
+        v-select(
+            label="Job Type",
+            :items="jobTypeList",
+            :value="jobType",
+            clearable,
+            color="white",
+            :menu-props="{'content-class':'girder-job-filter-form-menu'}",
+            dark,
+            dense,
+            @input="$emit('update:jobType', $event ? $event : null)")
+      v-flex(sm3, d-flex)
+        v-select(
+            label="Status",
+            :items="statusItemList",
+            :value="status",
+            clearable,
+            color="white",
+            :menu-props="{'content-class':'girder-job-filter-form-menu'}",
+            dark,
+            dense,
+            @input="$emit('update:status', $event ? $event : null)")
+</template>
+
+<style lang="scss">
+.girder-job-filter-form-menu .v-list__tile--active.theme--light {
+  color: black !important;
+}
+</style>

--- a/src/components/job/JobList.vue
+++ b/src/components/job/JobList.vue
@@ -1,0 +1,129 @@
+<script>
+import { stringify } from 'qs';
+
+import JobTable from './JobTable.vue';
+import FilterForm from './FilterForm.vue';
+
+export default {
+  inject: ['girderRest', 'notificationBus'],
+  components: {
+    JobTable,
+    FilterForm,
+  },
+  data() {
+    return {
+      jobFilter: {
+        fromDate: null,
+        toDate: null,
+        status: null,
+        jobType: null,
+      },
+      pagination: {
+        rowsPerPage: 10,
+        page: 1,
+        sortBy: 'updated',
+        descending: true,
+      },
+      morePages: true,
+      refresh: 0,
+    };
+  },
+  watch: {
+    // reset to the first page when the filter changes
+    jobFilter: {
+      handler() {
+        this.pagination.page = 1;
+      },
+      deep: true,
+    },
+  },
+  asyncComputed: {
+    jobs: {
+      async get() {
+        // eslint-disable-next-line no-unused-expressions
+        this.girderRest.user; // reload when the user changes
+        // eslint-disable-next-line no-unused-expressions
+        this.refresh; // reload when this value changes
+        const pg = this.pagination;
+        const params = {
+          limit: pg.rowsPerPage + 1, // get one more than the requested limit to detect next page
+          offset: pg.rowsPerPage * (pg.page - 1),
+        };
+        if (pg.sortBy) {
+          params.sort = pg.sortBy;
+          params.sortdir = pg.descending ? -1 : 1;
+        }
+        if (this.jobFilter.status !== null) {
+          params.statuses = JSON.stringify([this.jobFilter.status]);
+        }
+        if (this.jobFilter.jobType !== null) {
+          params.types = JSON.stringify([this.jobFilter.jobType]);
+        }
+        const resp = await this.girderRest.get(`job?${stringify(params)}`);
+        // set the morePages prop on the data table and slice to real count
+        if (resp.data.length < params.limit) {
+          this.morePages = false;
+        } else {
+          this.morePages = true;
+        }
+        return resp.data.slice(0, pg.rowsPerPage);
+      },
+      default() {
+        return [];
+      },
+    },
+    typeAndStatusList: {
+      async get() {
+        // eslint-disable-next-line no-unused-expressions
+        this.girderRest.user; // reload when the user changes
+        const resp = await this.girderRest.get('job/typeandstatus');
+        return resp.data;
+      },
+      default() {
+        return {
+          statuses: [],
+          types: [],
+        };
+      },
+    },
+  },
+  mounted() {
+    // trigger a fetch when a job status update occurs
+    this.refreshJobFunc = () => { this.refreshJobList(); };
+    this.notificationBus.$on('message:job_status', this.refreshJobFunc);
+    this.notificationBus.$on('message:job_created', this.refreshJobFunc);
+  },
+  beforeDestroy() {
+    this.notificationBus.$off('message:job_status', this.refreshJobFunc);
+    this.notificationBus.$off('message:job_created', this.refreshJobFunc);
+  },
+  methods: {
+    refreshJobList() {
+      // Vue with prevent the update happening more than once per animation frame,
+      // but we might want to add an extra debounce to prevent excessive rest
+      // calls.
+      this.refresh += 1;
+    },
+  },
+};
+</script>
+
+<template lang="pug">
+.girder-job-list
+  v-layout(row)
+    v-flex(xs12)
+      filter-form(
+          :from-date.sync="jobFilter.fromDate",
+          :to-date.sync="jobFilter.toDate",
+          :status.sync="jobFilter.status",
+          :job-type.sync="jobFilter.jobType",
+          :status-list="typeAndStatusList.statuses",
+          :job-type-list="typeAndStatusList.types")
+  v-layout(row)
+    v-flex(xs12)
+      job-table(
+          :jobs="jobs",
+          :pagination.sync="pagination",
+          :more-pages="morePages",
+          @job-click="(e, job)=>$emit('job-click', e, job)")
+</template>

--- a/src/components/job/JobTable.vue
+++ b/src/components/job/JobTable.vue
@@ -1,0 +1,148 @@
+<script>
+import moment from 'moment';
+import * as status from './status';
+
+export default {
+  props: {
+    jobs: {
+      type: Array,
+      required: true,
+    },
+    pagination: {
+      type: Object,
+      required: true,
+    },
+    morePages: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data() {
+    return {
+      headers: [{
+        text: 'Job Title',
+        value: 'title',
+      }, {
+        text: 'Type',
+        value: 'type',
+      }, {
+        text: 'Last Updated',
+        value: 'updated',
+      }, {
+        text: 'Status',
+        value: 'status',
+      }],
+    };
+  },
+  computed: {
+    items() {
+      return this.jobs.map(this.mapJobToRow);
+    },
+    totalItems() {
+      let { last } = this.pageRange;
+      if (this.morePages) {
+        last += 1;
+      }
+      return last;
+    },
+    pageRange() {
+      const first = (this.pagination.rowsPerPage * (this.pagination.page - 1)) + 1;
+      const last = (first + this.jobs.length) - 1;
+      return { first, last };
+    },
+  },
+  methods: {
+    mapJobToRow(job) {
+      const statusDef = Object.assign({ text: 'Unknown' }, status.getByValue(job.status));
+      return Object.assign({
+        statusText: statusDef.text,
+        statusColor: statusDef.color,
+        statusTextColor: statusDef.textColor || 'white',
+        statusIcon: statusDef.icon,
+        updateString: moment(job.updated).format('dddd, MMMM D, YYYY @ h:mm a'),
+        progressNumber: this.progressAsNumber(job.progress),
+        indeterminate: statusDef.indeterminate,
+        spin: statusDef.spin,
+      }, job);
+    },
+    progressAsNumber(progress) {
+      if (!progress) {
+        return 100;
+      }
+      return 100 * (progress.current / progress.total);
+    },
+  },
+};
+</script>
+
+<template lang="pug">
+v-card
+  v-data-table(
+      item-key="_id",
+      :headers="headers",
+      :items="items",
+      :total-items="totalItems",
+      :pagination="pagination",
+      @update:pagination="$emit('update:pagination', $event)")
+    template(slot="items", slot-scope="props")
+      tr(@click="$emit('job-click', $event, props.item)")
+        td {{ props.item.title }}
+        td.one-line {{ props.item.type }}
+        td.one-line {{ props.item.updateString }}
+        td.one-line.status-line(nowrap, :title="props.item.statusText")
+          v-layout(row)
+            v-flex(sm10)
+              v-progress-linear.mr-2.progress-bar(
+                  :color="props.item.statusColor",
+                  :value="props.item.progressNumber",
+                  :indeterminate="!!props.item.indeterminate",
+                  height="10")
+            v-flex.txt-xs-right(s1, pl-1)
+              v-icon.status-icon(
+                  :color="props.item.statusColor",
+                  :class="{ rotate: props.item.spin }",
+                  :size="20") {{ props.item.statusIcon }}
+
+    template(slot="pageText", slot-scope="props")
+      .v-datatable__actions__pagination {{ pageRange.first }}-{{ pageRange.last }}
+</template>
+
+<style lang="scss" scoped>
+.one-line {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status-line {
+  .progress-bar {
+    width: 150px;
+  }
+
+  .progress-text {
+    position: relative;
+    top: 1px;
+    font-weight: 500;
+  }
+
+  .status-icon {
+    height: 100%;
+    position: relative;
+    top: -1px;
+  }
+}
+
+.rotate {
+  animation: rotation 1.5s infinite linear;
+
+  @keyframes rotation {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(359deg);
+    }
+  }
+}
+</style>

--- a/src/components/job/index.js
+++ b/src/components/job/index.js
@@ -1,0 +1,15 @@
+import FilterForm from './FilterForm.vue';
+import JobList from './JobList.vue';
+import JobTable from './JobTable.vue';
+
+export {
+  FilterForm,
+  JobList,
+  JobTable,
+};
+
+export default {
+  FilterForm,
+  JobList,
+  JobTable,
+};

--- a/src/components/job/status.js
+++ b/src/components/job/status.js
@@ -1,0 +1,98 @@
+const statusMap = {
+  INACTIVE: {
+    value: 0,
+    text: 'Inactive',
+    icon: 'mdi-pause',
+    color: 'grey lighten-1',
+  },
+  QUEUED: {
+    value: 1,
+    text: 'Queued',
+    icon: 'mdi-dots-horizontal',
+    color: 'yellow darken-2',
+    indeterminate: true,
+  },
+  RUNNING: {
+    value: 2,
+    text: 'Running',
+    icon: 'mdi-autorenew',
+    color: 'light-blue',
+    spin: true,
+  },
+  SUCCESS: {
+    value: 3,
+    text: 'Success',
+    icon: 'mdi-check-circle',
+    color: 'green',
+  },
+  ERROR: {
+    value: 4,
+    text: 'Error',
+    icon: 'mdi-alert-circle',
+    color: 'red',
+  },
+  CANCELED: {
+    value: 5,
+    text: 'Canceled',
+    icon: 'mdi-close-circle',
+    color: 'grey darken-1',
+  },
+  WORKER_FETCHING_INPUT: {
+    value: 820,
+    text: 'Fetching input',
+    icon: 'mdi-cloud-download',
+    color: 'light-blue lighten-2',
+    indeterminate: true,
+  },
+  WORKER_CONVERTING_INPUT: {
+    value: 821,
+    text: 'Converting input',
+    icon: 'mdi-shuffle',
+    color: 'lime',
+    indeterminate: true,
+  },
+  WORKER_CONVERTING_OUTPUT: {
+    value: 822,
+    text: 'Converting output',
+    icon: 'mdi-shuffle',
+    color: 'lime',
+    indeterminate: true,
+  },
+  WORKER_PUSHING_OUTPUT: {
+    value: 823,
+    text: 'Pushing output',
+    icon: 'mdi-cloud-upload',
+    color: 'light-blue lighten-2',
+    indeterminate: true,
+  },
+  WORKER_CANCELING: {
+    value: 824,
+    text: 'Canceling',
+    icon: 'mdi-alert',
+    color: 'grey darken-1',
+    indeterminate: true,
+  },
+};
+
+function all() {
+  return statusMap;
+}
+
+function get(statusName) {
+  return statusMap[statusName];
+}
+
+function getByValue(value) {
+  return Object.values(statusMap).find(status => status.value === value);
+}
+
+function register(status = {}) {
+  Object.assign(statusMap, status);
+}
+
+export {
+  all,
+  get,
+  getByValue,
+  register,
+};

--- a/tests/unit/job/FilterForm.spec.js
+++ b/tests/unit/job/FilterForm.spec.js
@@ -1,0 +1,72 @@
+import { mount } from '@vue/test-utils';
+import FilterForm from '@/components/job/FilterForm.vue';
+import * as status from '@/components/job/status';
+
+import { girderVue } from '../utils';
+
+const localVue = girderVue();
+
+describe('FilterForm.vue', () => {
+  let app;
+
+  // Fixes warning with certain vuetify components
+  // https://forum.vuejs.org/t/vuetify-data-app-true-and-problems-rendering-v-dialog-in-unit-tests/27495/2
+  beforeEach(() => {
+    app = document.createElement('div');
+    app.setAttribute('data-app', true);
+    document.body.appendChild(app);
+  });
+  afterEach(() => {
+    document.body.removeChild(app);
+  });
+
+  it('mount with job type list', () => {
+    const wrapper = mount(FilterForm, {
+      localVue,
+      propsData: {
+        jobTypeList: ['type 1', 'type 2'],
+      },
+    });
+    expect(wrapper.find({ name: 'v-select' }).vm.items).toEqual(['type 1', 'type 2']);
+  });
+
+  it('mount with status list', () => {
+    const wrapper = mount(FilterForm, {
+      localVue,
+      propsData: {
+        statusList: [0, 1, 2, 3],
+      },
+    });
+    const statusSelect = wrapper.findAll({ name: 'v-select' }).at(1);
+    expect(statusSelect.vm.items.map(s => s.value)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('mount with custom status item', () => {
+    status.register({
+      CUSTOM_TEST_STATUS: {
+        value: 999,
+        text: '0Custom', // make it sort first
+      },
+    });
+
+    const wrapper = mount(FilterForm, {
+      localVue,
+      propsData: {
+        statusList: [0, 1, 2, 999],
+      },
+    });
+    const statusSelect = wrapper.findAll({ name: 'v-select' }).at(1);
+    expect(statusSelect.vm.items.map(s => s.value)).toEqual([999, 0, 1, 2]);
+  });
+
+  it('mount with unknown status item', () => {
+    const wrapper = mount(FilterForm, {
+      localVue,
+      propsData: {
+        statusList: [0, 1, 2, 998],
+      },
+    });
+    const statusSelect = wrapper.findAll({ name: 'v-select' }).at(1);
+    expect(statusSelect.vm.items.map(s => s.value)).toEqual([0, 1, 2]);
+  });
+});

--- a/tests/unit/job/JobList.spec.js
+++ b/tests/unit/job/JobList.spec.js
@@ -1,0 +1,200 @@
+import Vue from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import MockAdapter from 'axios-mock-adapter';
+import RestClient from '@/rest';
+import JobList from '@/components/job/JobList.vue';
+
+import { girderVue } from '../utils';
+
+const localVue = girderVue();
+
+const job = {
+  title: 'job',
+  type: 'type',
+  updated: '2000-01-01T05:00:00.000',
+  status: 3,
+};
+
+describe('JobList.vue', () => {
+  const girderRest = new RestClient();
+  const mock = new MockAdapter(girderRest);
+  const notificationBus = new Vue();
+  let app;
+
+  async function waitForResponses(wrapper) {
+    await Promise.all([ /* eslint-disable no-underscore-dangle */
+      wrapper.vm._async_computed$jobs,
+      wrapper.vm._async_computed$typeAndStatusList,
+      wrapper.vm.$nextTick(),
+    ]);
+  }
+
+  async function mountAndWait(options = {}) {
+    const wrapper = shallowMount(JobList, Object.assign({
+      localVue,
+      provide: { girderRest, notificationBus },
+    }, options));
+    await waitForResponses(wrapper);
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    app = document.createElement('div');
+    app.setAttribute('data-app', true);
+    document.body.appendChild(app);
+    // localVue = createGirderVue();
+    // mock = localVue.prototype.$mock;
+  });
+  afterEach(() => {
+    document.body.removeChild(app);
+    // mock = null;
+    // localVue = null;
+    mock.reset();
+  });
+
+  it('mount with no jobs', async () => {
+    mock.onGet(/job[^/]/).reply(200, []);
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [],
+      types: [],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+    expect(wrapper.vm.jobs).toEqual([]);
+    expect(wrapper.vm.morePages).toBe(false);
+    expect(wrapper.vm.typeAndStatusList).toEqual({
+      statuses: [],
+      types: [],
+    });
+  });
+
+  it('mount with one job', async () => {
+    mock.onGet(/job[^/]/).reply(200, [job]);
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [0, 1],
+      types: ['type 1', 'type 2'],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+    expect(wrapper.vm.jobs).toEqual([job]);
+    expect(wrapper.vm.morePages).toBe(false);
+    expect(wrapper.vm.typeAndStatusList).toEqual({
+      statuses: [0, 1],
+      types: ['type 1', 'type 2'],
+    });
+  });
+
+  it('mount with pagination', async () => {
+    mock.onGet(/job[^/]/).reply(200, [...Array(11).keys()].map(() => () => job));
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [0, 1],
+      types: ['type 1', 'type 2'],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+    wrapper.vm.pagination.rowsPerPage = 10;
+    expect(wrapper.vm.jobs.length).toBe(10);
+    expect(wrapper.vm.morePages).toBe(true);
+  });
+
+  it('responds to filter changes', async () => {
+    mock.onGet(/job[^/]/).reply(200, [...Array(11).keys()].map(() => () => job));
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [0, 1],
+      types: ['type 1', 'type 2'],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+
+    wrapper.vm.pagination.page = 2;
+    await waitForResponses(wrapper);
+
+    mock.resetHistory();
+    wrapper.vm.jobFilter = {
+      status: 0,
+      jobType: 'type 1',
+    };
+    await waitForResponses(wrapper);
+    expect(mock.history.get.length).toBe(1);
+    expect(mock.history.get[0].url).toMatch(/statuses=%5B0%5D/);
+    expect(mock.history.get[0].url).toMatch(/types=%5B%22type%201%22%5D/);
+    expect(wrapper.vm.pagination.page).toBe(1);
+  });
+
+  it('responds to pagination changes', async () => {
+    mock.onGet(/job[^/]/).reply(200, [...Array(11).keys()].map(() => () => job));
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [0, 1],
+      types: ['type 1', 'type 2'],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+
+    mock.resetHistory();
+    wrapper.vm.pagination = {
+      rowsPerPage: 10,
+      page: 3,
+      sortBy: 'title',
+      descending: false,
+    };
+    await waitForResponses(wrapper);
+
+    expect(mock.history.get.length).toBe(1);
+    expect(mock.history.get[0].url).toMatch(/limit=11/);
+    expect(mock.history.get[0].url).toMatch(/offset=20/);
+    expect(mock.history.get[0].url).toMatch(/sort.*title/);
+    expect(mock.history.get[0].url).toMatch(/sortdir=1/);
+  });
+
+  it('default sort order', async () => {
+    mock.onGet(/job[^/]/).reply(200, [...Array(11).keys()].map(() => () => job));
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [0, 1],
+      types: ['type 1', 'type 2'],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+
+    mock.resetHistory();
+    wrapper.vm.pagination = {
+      rowsPerPage: 10,
+      page: 3,
+    };
+    await waitForResponses(wrapper);
+
+    expect(mock.history.get.length).toBe(1);
+    expect(mock.history.get[0].url).not.toMatch(/sort/);
+  });
+
+  it('updates on job notifications', async () => {
+    mock.onGet(/job[^/]/).reply(200, [job]);
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [],
+      types: [],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+    const spy = jest.spyOn(wrapper.vm, 'refreshJobList');
+
+    notificationBus.$emit('message:job_status');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    notificationBus.$emit('message:job_created');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh fetches server', async () => {
+    mock.onGet(/job[^/]/).reply(200, [job]);
+    mock.onGet(/typeandstatus$/).reply(200, {
+      statuses: [],
+      types: [],
+    });
+
+    const wrapper = await mountAndWait(JobList);
+    const fetchCount = mock.history.get.length;
+    wrapper.vm.refreshJobList();
+    await waitForResponses(wrapper);
+
+    expect(mock.history.get.length).toBeGreaterThan(fetchCount);
+  });
+});

--- a/tests/unit/job/JobTable.spec.js
+++ b/tests/unit/job/JobTable.spec.js
@@ -1,0 +1,92 @@
+import { mount } from '@vue/test-utils';
+import JobTable from '@/components/job/JobTable.vue';
+
+import { girderVue } from '../utils';
+
+const localVue = girderVue();
+
+const job = {
+  title: 'job',
+  type: 'type',
+  updated: '2000-01-01T05:00:00.000',
+  status: 3,
+};
+
+describe('JobTable.vue', () => {
+  let app;
+
+  // Fixes warning with certain vuetify components
+  // https://forum.vuejs.org/t/vuetify-data-app-true-and-problems-rendering-v-dialog-in-unit-tests/27495/2
+  beforeEach(() => {
+    app = document.createElement('div');
+    app.setAttribute('data-app', true);
+    document.body.appendChild(app);
+  });
+  afterEach(() => {
+    document.body.removeChild(app);
+  });
+
+  it('mount with no data', () => {
+    const wrapper = mount(JobTable, {
+      localVue,
+      propsData: {
+        jobs: [],
+        pagination: {},
+      },
+    });
+    expect(wrapper.find('tbody').text()).toBe('No data available');
+  });
+
+  it('mount with one job', () => {
+    const wrapper = mount(JobTable, {
+      localVue,
+      propsData: {
+        jobs: [job],
+        pagination: {
+          page: 1,
+          rowsPerPage: 10,
+        },
+        morePages: false,
+      },
+    });
+    expect(wrapper.vm.pageRange).toEqual({
+      first: 1,
+      last: 1,
+    });
+    expect(wrapper.vm.totalItems).toBe(1);
+  });
+
+  it('mount with pagination', () => {
+    const wrapper = mount(JobTable, {
+      localVue,
+      propsData: {
+        jobs: [...Array(10).keys()].map(() => () => job),
+        pagination: {
+          page: 2,
+          rowsPerPage: 10,
+        },
+        morePages: true,
+      },
+    });
+    expect(wrapper.vm.pageRange).toEqual({
+      first: 11,
+      last: 20,
+    });
+    expect(wrapper.vm.totalItems).toBe(21);
+  });
+
+  it('convert progress object to a value', () => {
+    const wrapper = mount(JobTable, {
+      localVue,
+      propsData: {
+        jobs: [],
+        pagination: {},
+      },
+    });
+    expect(wrapper.vm.progressAsNumber(null)).toBe(100);
+    expect(wrapper.vm.progressAsNumber({
+      current: 50,
+      total: 100,
+    })).toBe(50);
+  });
+});

--- a/tests/unit/job/Status.spec.js
+++ b/tests/unit/job/Status.spec.js
@@ -1,0 +1,39 @@
+import * as status from '@/components/job/status';
+
+describe('job/status', () => {
+  it('get a built in status by key', () => {
+    expect(status.get('SUCCESS').value).toBe(3);
+  });
+
+  it('get a built in status by value', () => {
+    expect(status.getByValue(3).text).toBe('Success');
+  });
+
+  it('get unknown status by key', () => {
+    expect(status.get('not registered')).toBe(undefined);
+  });
+
+  it('get unknown status by value', () => {
+    expect(status.getByValue(-999)).toBe(undefined);
+  });
+
+  it('get all statuses', () => {
+    expect(status.all()).not.toEqual({});
+  });
+
+  it('register a custom status', () => {
+    status.register({
+      CUSTOM_STATUS: {
+        value: 9999,
+        text: 'custom',
+      },
+    });
+    expect(status.get('CUSTOM_STATUS')).toEqual({ value: 9999, text: 'custom' });
+  });
+
+  it('register no-op', () => {
+    const all = status.all();
+    status.register();
+    expect(status.all()).toEqual(all);
+  });
+});

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,14 @@
+const webpack = require('webpack'); // eslint-disable-line import/no-extraneous-dependencies
+
 module.exports = {
   lintOnSave: false,
   // publicPath only affects demo application deployed to GH pages.
   publicPath: process.env.NODE_ENV === 'production'
     ? '/girder_web_components'
     : '/',
+  configureWebpack: {
+    plugins: [
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    ],
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6516,6 +6516,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
This ports the Job Listing components from https://github.com/Kitware/resonantgeo
The development ResonantGeo will focus on Geospatial components and won't have the Job Listing components.
However, at this moment, Vigilant is using the Job Listing component, so it is important to have it moved to here and merge this sooner rather than later.

![2019-07-06_07-24-22](https://user-images.githubusercontent.com/3123478/60809835-a2fa8880-a159-11e9-8c4b-e6dd7e684767.gif)

