### PR TITLE
Update boolean props

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -17,7 +17,7 @@ v-app.app
               v-checkbox.mt-2(hide-details, label="Select", v-model="selectEnabled")
               v-checkbox.mt-1(hide-details, label="Draggable", v-model="dragEnabled")
               v-checkbox.mt-1(hide-details, label="New Folder", v-model="newFolderEnabled")
-              v-checkbox.mt-1(hide-details, label="Upload", v-model="newItemEnabled")
+              v-checkbox.mt-1(hide-details, label="Upload", v-model="uploadEnabled")
               v-checkbox.mt-1.mb-1(hide-details, label="Search Box", v-model="searchEnabled")
               v-divider
               v-list(dense)
@@ -54,10 +54,10 @@ v-app.app
           girder-data-browser(
               ref="girderBrowser",
               :location.sync="location",
-              :select-enabled="selectEnabled",
+              :selection="selectEnabled",
               :draggable="dragEnabled",
-              :new-item-enabled="newItemEnabled",
-              :new-folder-enabled="newFolderEnabled",
+              :upload="uploadEnabled",
+              :new-folder="newFolderEnabled",
               @click:newitem="uploader = true",
               @click:newfolder="newFolder = true",
               @selection-changed="selected = $event")
@@ -89,7 +89,6 @@ export default {
   },
   data() {
     return {
-      multiple: true,
       uploader: false,
       newFolder: false,
       uiOptionsMenu: false,
@@ -97,7 +96,7 @@ export default {
       forgotPasswordUrl: '/#?dialog=resetpassword',
       dragEnabled: false,
       selectEnabled: true,
-      newItemEnabled: true,
+      uploadEnabled: true,
       newFolderEnabled: true,
       searchEnabled: true,
       selected: [],

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -16,7 +16,7 @@ export default {
       type: Array,
       default: () => [],
     },
-    noRoot: {
+    rootLocation: {
       type: Boolean,
       default: false,
     },
@@ -62,7 +62,7 @@ export default {
           const { data } = await this.girderRest.get(`${type}/${_id}`);
           breadcrumb.unshift(this.extractCrumbData(data));
         }
-        if (!this.noRoot) {
+        if (this.rootLocation) {
           if (
             type === 'users' ||
             (user && breadcrumb.length && breadcrumb[0].type === 'user')
@@ -83,8 +83,8 @@ export default {
     },
   },
   created() {
-    if (!createLocationValidator(false)(this.location) && this.noRoot) {
-      throw new Error("non root location can't be used with no-root prop at the same time");
+    if (!createLocationValidator(true)(this.location) === 'root' && !this.rootLocation) {
+      throw new Error("Root location can't be used without root-location prop");
     }
   },
   methods: {

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -17,7 +17,7 @@ export default {
       type: Array,
       required: true,
     },
-    selectEnabled: {
+    selection: {
       type: Boolean,
       required: true,
     },
@@ -35,7 +35,7 @@ export default {
   },
   methods: {
     handleRowSelect({ shiftKey }, props) {
-      if (this.selectEnabled) {
+      if (this.selection) {
         props.selected = !props.selected;
         if (shiftKey && this.lastCheckBoxIdx !== null) {
           const [start, end] = [this.lastCheckBoxIdx, props.index + 1].sort();
@@ -74,19 +74,19 @@ v-data-table.girder-data-table(
 
   template(slot="items", slot-scope="props")
     tr.itemRow(:draggable="draggable", :active="props.selected",
-        :class="{ selectable: !selectEnabled }",
+        :class="{ selectable: selection }",
         @click="handleRowSelect($event, props)",
         @drag="$emit('drag', { items: [props], event: $event })",
         @dragstart="$emit('dragstart', { items: [props], event: $event })",
         @dragend="$emit('dragend', { items: [props], event: $event })",
         @drop="$emit('drop', { items: [props], event: $event })",
         :key="props.index")
-      td.pl-3.pr-0(v-if="selectEnabled")
+      td.pl-3.pr-0(v-if="selection")
         v-checkbox.secondary--text.text--darken-1.pr-2(
             :input-value="props.selected", accent, hide-details)
       td.pl-3(colspan="2")
         span.text-container.secondary--text.text--darken-3.nobreak(
-            :class="{ selectable: selectEnabled && props.item._modelType !== 'item' }",
+            :class="{ selectable: selection && props.item._modelType !== 'item' }",
             @click.stop="$emit('rowclick', props.item)")
           v-icon.pr-2(:color="props.selected ? 'accent' : ''") {{ $vuetify.icons[props.item.icon] }}
           | {{ props.item.name }}

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -10,7 +10,7 @@ export default {
     },
     showMore: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   inject: ['girderRest'],

--- a/src/components/UpsertFolder.vue
+++ b/src/components/UpsertFolder.vue
@@ -124,8 +124,7 @@ v-form(@submit.prevent="upsert")
         girder-breadcrumb.mb-3(
             :location="location",
             :append="append",
-            readonly,
-            no-root)
+            readonly)
         girder-markdown-editor(
             v-model="description",
             label="Description (Optional)")

--- a/src/components/UpsertFolder.vue
+++ b/src/components/UpsertFolder.vue
@@ -123,8 +123,8 @@ v-form(@submit.prevent="upsert")
               label="Folder Name")
         girder-breadcrumb.mb-3(
             :location="location",
-            :disabled="true",
             :append="append",
+            readonly,
             no-root)
         girder-markdown-editor(
             v-model="description",

--- a/src/utils/createLocationValidator.js
+++ b/src/utils/createLocationValidator.js
@@ -5,10 +5,10 @@ export default function (allowRoot) {
     }
     const { type, _modelType, _id } = location;
     if (['user', 'collection', 'folder'].indexOf(_modelType) !== -1 && _id) {
-      return true;
+      return 'model';
     }
     if (allowRoot && ['collections', 'users', 'root'].indexOf(type) !== -1) {
-      return true;
+      return 'root';
     }
     return false;
   };

--- a/tests/unit/Breadcrumb.spec.js
+++ b/tests/unit/Breadcrumb.spec.js
@@ -156,7 +156,6 @@ describe('Breadcrumb', () => {
     });
     await flushPromises();
     expect(wrapper.vm.breadcrumb[0].type).toBe('root');
-    expect(wrapper.findAll('vbreadcrumbs-stub vicon-stub').at(0).text()).toBe('mdi-earth');
 
     wrapper.setProps({
       location: {
@@ -166,8 +165,6 @@ describe('Breadcrumb', () => {
     await flushPromises();
     expect(wrapper.vm.breadcrumb.length).toBe(2);
     expect(wrapper.vm.breadcrumb[1].type).toBe('collections');
-    expect(wrapper.findAll('vbreadcrumbs-stub vicon-stub').at(0).text()).toBe('mdi-earth');
-    expect(wrapper.findAll('vbreadcrumbs-stub vicon-stub').at(1).text()).toBe('mdi-file-tree');
 
     wrapper.setProps({
       location: {
@@ -207,7 +204,6 @@ describe('Breadcrumb', () => {
     await flushPromises();
     expect(wrapper.vm.breadcrumb.length).toBe(3);
     expect(wrapper.vm.breadcrumb[1].type).toBe('users');
-    expect(wrapper.findAll('vbreadcrumbs-stub vicon-stub').at(1).text()).toBe('mdi-account');
     expect(wrapper.find('.home-button').exists()).toBe(true);
   });
 });

--- a/tests/unit/Breadcrumb.spec.js
+++ b/tests/unit/Breadcrumb.spec.js
@@ -97,7 +97,6 @@ describe('Breadcrumb', () => {
           _modelType: 'folder',
           _id: 'fake_folder_id',
         },
-        noRoot: true,
       },
       provide: { girderRest },
     });
@@ -135,7 +134,6 @@ describe('Breadcrumb', () => {
           _modelType: 'user',
           _id: 'fake_userid',
         },
-        noRoot: true,
       },
       provide: { girderRest },
     });
@@ -151,6 +149,7 @@ describe('Breadcrumb', () => {
         location: {
           type: 'root',
         },
+        rootLocation: true,
       },
       provide: { girderRest },
     });
@@ -184,6 +183,7 @@ describe('Breadcrumb', () => {
           _modelType: 'user',
           _id: 'fake_userid',
         },
+        rootLocation: true,
       },
       provide: { girderRest },
     });
@@ -198,6 +198,7 @@ describe('Breadcrumb', () => {
           _modelType: 'user',
           _id: 'fake_userid',
         },
+        rootLocation: true,
       },
       provide: { girderRest: await authenticateRestClient(girderRest, mock) },
     });

--- a/tests/unit/DataBrowser.spec.js
+++ b/tests/unit/DataBrowser.spec.js
@@ -69,11 +69,6 @@ describe('DataBrowser', () => {
           _modelType: 'user',
           _id: 'foo_user_id',
         },
-        selectEnabled: false,
-        multiSelectEnabled: false,
-        uploadEnabled: false,
-        newItemEnabled: false,
-        newFolderEnabled: false,
       },
       provide: { girderRest },
     });
@@ -120,11 +115,6 @@ describe('DataBrowser', () => {
           _modelType: 'folder',
           _id: 'fake_folder_id',
         },
-        selectEnabled: false,
-        multiSelectEnabled: false,
-        uploadEnabled: false,
-        newItemEnabled: false,
-        newFolderEnabled: false,
       },
       data: () => ({
         pagination: {
@@ -165,11 +155,6 @@ describe('DataBrowser', () => {
           _modelType: 'folder',
           _id: 'fake_folder_id',
         },
-        selectEnabled: false,
-        multiSelectEnabled: false,
-        uploadEnabled: false,
-        newItemEnabled: false,
-        newFolderEnabled: false,
       },
       data: () => ({
         pagination: {
@@ -211,11 +196,6 @@ describe('DataBrowser', () => {
           _modelType: 'folder',
           _id: 'fake_folder_id',
         },
-        selectEnabled: false,
-        multiSelectEnabled: false,
-        uploadEnabled: false,
-        newItemEnabled: false,
-        newFolderEnabled: false,
       },
       data: () => ({
         pagination: {
@@ -242,11 +222,11 @@ describe('DataBrowser', () => {
     expect(validator({ _modelType: 'folder' })).toBe(false);
     expect(validator({ _modelType: 'user' })).toBe(false);
     expect(validator({ _modelType: 'collection' })).toBe(false);
-    expect(validator({ _modelType: 'folder', _id: 'fake_folder_id' })).toBe(true);
-    expect(validator({ _modelType: 'user', _id: 'fake_user_id' })).toBe(true);
-    expect(validator({ type: 'root' })).toBe(true);
-    expect(validator({ type: 'users' })).toBe(true);
-    expect(validator({ type: 'collections' })).toBe(true);
+    expect(validator({ _modelType: 'folder', _id: 'fake_folder_id' })).toBe('model');
+    expect(validator({ _modelType: 'user', _id: 'fake_user_id' })).toBe('model');
+    expect(validator({ type: 'root' })).toBe('root');
+    expect(validator({ type: 'users' })).toBe('root');
+    expect(validator({ type: 'collections' })).toBe('root');
   });
 
   it('default root location', async () => {


### PR DESCRIPTION
This PR 
- Fix an issue related to breadcrumb. 
- Improved the girder-breadcrumb component. There always has been console warnings complaining about deprecated slot usage with v-breadcrumb. This commit fixes that issue and prepared for the new slot syntax. This commit also fixes a couple of issues introduced in the previous PR.
- Makes boolean props always negate its default value, so their default value can be deduced from the naming itself, and that when using the props, only the name is needed.
This commit also removes a couple of unused props. e.g. one of the props was called newFolderEnabled but it has a default value of true, so, it has to be set as :new-folder-enabled='false' to use it. It has been renamed to `new-folder`, to indicate it's default value is false, and when using, only need the mention the prop without value <girder-data-browser new-folder />