### PR TITLE
Serve from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Girder web component library
 
-Try the [demo app](https://girder.github.io/girder_web_components/).
+Try the [demo app](https://gwc.girder.org/).
 It works with [data.kitware.com](https://data.kitware.com/).
 
 ## Usage Quckstart

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,10 +2,7 @@ const webpack = require('webpack'); // eslint-disable-line import/no-extraneous-
 
 module.exports = {
   lintOnSave: false,
-  // publicPath only affects demo application deployed to GH pages.
-  publicPath: process.env.NODE_ENV === 'production'
-    ? '/girder_web_components'
-    : '/',
+  publicPath: '/',
   configureWebpack: {
     plugins: [
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),


### PR DESCRIPTION
I've gone ahead and cut over the pages site to gwc.girder.org to trigger certificate generation on github's side.  I _think_ this is configured correctly, but we'll just have to wait and see.

Meanwhile, these changes are needed.