### PR TITLE
Add cname file

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+gwc.girder.org


### PR DESCRIPTION
Turns out that UI element was actually generating the CNAME file and committing it to the gh-pages branch which our CI overwrites with a force push.  Silently committing from github settings UI seems like a terrible design choice, but whatever.  

Here's the fix.