### PR TITLE
Token from oAuth reply

### DIFF
--- a/src/components/Authentication/Authentication.vue
+++ b/src/components/Authentication/Authentication.vue
@@ -16,6 +16,7 @@ v-card.girder-authentication-component
 <script>
 import GirderLogin from './Login.vue';
 import GirderRegistration from './Register.vue';
+import { OauthTokenPrefix, OauthTokenSuffix } from '../../rest.js';
 
 export default {
   inject: ['girderRest'],
@@ -61,7 +62,7 @@ export default {
         try {
           return (await this.girderRest.get('oauth/provider', {
             params: {
-              redirect: window.location.href,
+              redirect: `${window.location.href}${OauthTokenPrefix}{girderToken}${OauthTokenSuffix}`,
               list: true,
             },
           })).data;

--- a/src/components/Authentication/Authentication.vue
+++ b/src/components/Authentication/Authentication.vue
@@ -16,7 +16,7 @@ v-card.girder-authentication-component
 <script>
 import GirderLogin from './Login.vue';
 import GirderRegistration from './Register.vue';
-import { OauthTokenPrefix, OauthTokenSuffix } from '../../rest.js';
+import { OauthTokenPrefix, OauthTokenSuffix } from '../../rest';
 
 export default {
   inject: ['girderRest'],

--- a/src/rest.js
+++ b/src/rest.js
@@ -20,7 +20,7 @@ function setCookieFromHash(location) {
   const token = arr[arr.length - 1].split(OauthTokenSuffix)[0];
   if (token.length === GirderTokenLength) {
     const expires = new Date();
-    expires.setDate((new Date()).getDate() + 7);
+    expires.setDate((new Date()).getDate() + 365);
     setCookieFromAuth({ token, expires });
     location.hash = location.hash.replace(`${OauthTokenPrefix}${token}${OauthTokenSuffix}`, '');
   }


### PR DESCRIPTION
Nothing too special here.  Worth noting that I think it's sufficient to do a rewrite on the `location.hash` of the page after getting the token from there.  This library isn't in control of page location, so there may be virtual hash routes from a vue router we don't want to change.

Here's a complex example:

```text
// before redirect
http://origin.com/path?query#/virtual/path#girderToken={girderToken}__
// after first redirect @ girder, girder fills the template string.  It may also append whatever other noise it wants -- that's the reason for the suffix.
redirect_to = http://origin.com/path?query#/virtual/path#girderToken=tokenstring__#other/stuff?
// after GWC has loaded, location should look like this:
http://origin.com/path?query#/virtual/path#other/stuff?
```

fixes #73 