### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Try the [demo app](https://gwc.girder.org/).
 It works with [data.kitware.com](https://data.kitware.com/).
 
-## Usage Quckstart
+## Usage Quickstart
 
 ### Installation
 
@@ -30,15 +30,9 @@ If you are building using webpack, add the following to your module rules in web
 {
   test: /.styl$/,
   use: [
-    {
-      loader: "style-loader",
-    },
-    {
-      loader: "css-loader",
-    },
-    {
-      loader: "stylus-loader",
-    },
+      "style-loader",
+      "css-loader",
+      "stylus-loader",
   ],
 },
 {
@@ -50,8 +44,6 @@ If you are building using webpack, add the following to your module rules in web
   ],
 },
 ```
-
-
 
 ### Initialization
 


### PR DESCRIPTION
Hi! We're working on using girder web components in paraview glance and ran into a few bumps. Specifically: 
webpack needs special configuration for .pug, .styl, and .sass files
sass-loader has a regression in 8.0, so 7.31 should be used for now

This pull request adds this information to Readme.md
