### PR TITLE
Allow upstream to specify upload phrase

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -14,7 +14,7 @@ v-card.fill-height(flat)
 
     v-card-actions(v-show="files.length && !errorMessage && !uploading")
       v-btn(text, @click="files = []") Clear all
-      v-btn(text, color="primary", @click="start") Start upload
+      v-btn(text, color="primary", @click="start") {{ uploadPhrase }}
 
     v-col
       slot(name="dropzone")
@@ -72,6 +72,10 @@ export default {
     },
     accept: {
       default: null,
+      type: String,
+    },
+    uploadPhrase: {
+      default: 'Start Upload',
       type: String,
     },
   },

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -14,7 +14,7 @@ v-card.fill-height(flat)
 
     v-card-actions(v-show="files.length && !errorMessage && !uploading")
       v-btn(text, @click="files = []") Clear all
-      v-btn(text, color="primary", @click="start") {{ uploadPhrase }}
+      v-btn(text, color="primary", @click="start") {{ startButtonText }}
 
     v-col
       slot(name="dropzone")
@@ -74,7 +74,7 @@ export default {
       default: null,
       type: String,
     },
-    uploadPhrase: {
+    startButtonText: {
       default: 'Start Upload',
       type: String,
     },


### PR DESCRIPTION
A customer adamantly wants a different phrase for that button.  This seems like a low maintenance burden.