### PR TITLE
Prop in Auth and Login components to hide Forgot Password

### DIFF
--- a/src/components/Authentication/Authentication.vue
+++ b/src/components/Authentication/Authentication.vue
@@ -7,7 +7,7 @@ v-card.girder-authentication-component
   v-tabs-items(v-model="activeTab")
     v-tab-item(key="login-box")
       girder-login(:oauth-providers="oauthProviders",
-          v-bind="{ forceOtp, forgotPasswordUrl, forgotPasswordRoute, showForgotPassword }",
+          v-bind="{ forceOtp, forgotPasswordUrl, forgotPasswordRoute, hideForgotPassword }",
           @forgotpassword="$emit('forgotpassword')")
     v-tab-item(key="registration-box", v-if="register")
       girder-registration(:oauth-providers="oauthProviders")
@@ -50,9 +50,9 @@ export default {
       type: Boolean,
       default: false,
     },
-    showForgotPassword: {
+    hideForgotPassword: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   data() {

--- a/src/components/Authentication/Authentication.vue
+++ b/src/components/Authentication/Authentication.vue
@@ -7,9 +7,7 @@ v-card.girder-authentication-component
   v-tabs-items(v-model="activeTab")
     v-tab-item(key="login-box")
       girder-login(:oauth-providers="oauthProviders",
-          :force-otp="forceOtp",
-          :forgot-password-url="forgotPasswordUrl",
-          :forgot-password-route="forgotPasswordRoute",
+          v-bind="{ forceOtp, forgotPasswordUrl, forgotPasswordRoute, showForgotPassword }",
           @forgotpassword="$emit('forgotpassword')")
     v-tab-item(key="registration-box", v-if="register")
       girder-registration(:oauth-providers="oauthProviders")
@@ -51,6 +49,10 @@ export default {
     forceOtp: {
       type: Boolean,
       default: false,
+    },
+    showForgotPassword: {
+      type: Boolean,
+      default: true,
     },
   },
   data() {

--- a/src/components/Authentication/Login.vue
+++ b/src/components/Authentication/Login.vue
@@ -38,10 +38,11 @@
             :loading="inProgress")
           v-icon(left) $vuetify.icons.login
           | {{ otpFormVisible ? 'Verify code' : 'Login' }}
-        v-spacer
-        v-btn(
-            text, color="primary", :to="forgotPasswordRoute", :href="forgotPasswordUrl",
-            @click="$emit('forgotpassword')") Forgot Password?
+        template(v-if="showForgotPassword")
+          v-spacer
+          v-btn(
+              text, color="primary", :to="forgotPasswordRoute", :href="forgotPasswordUrl",
+              @click="$emit('forgotpassword')") Forgot Password?
   template(v-if="oauthProviders && oauthProviders.length")
     v-divider
     girder-oauth(:providers="oauthProviders")
@@ -89,6 +90,10 @@ export default {
     oauthProviders: {
       type: Array,
       default: () => [],
+    },
+    showForgotPassword: {
+      type: Boolean,
+      default: true,
     },
   },
   data() {

--- a/src/components/Authentication/Login.vue
+++ b/src/components/Authentication/Login.vue
@@ -38,7 +38,7 @@
             :loading="inProgress")
           v-icon(left) $vuetify.icons.login
           | {{ otpFormVisible ? 'Verify code' : 'Login' }}
-        template(v-if="showForgotPassword")
+        template(v-if="!hideForgotPassword")
           v-spacer
           v-btn(
               text, color="primary", :to="forgotPasswordRoute", :href="forgotPasswordUrl",
@@ -87,13 +87,13 @@ export default {
       type: Object,
       default: null,
     },
+    hideForgotPassword: {
+      type: Boolean,
+      default: false,
+    },
     oauthProviders: {
       type: Array,
       default: () => [],
-    },
-    showForgotPassword: {
-      type: Boolean,
-      default: true,
     },
   },
   data() {


### PR DESCRIPTION
In some cases (e.g. pluggable auth on the backend), downstreams won't want a forgotten password flow to go through Girder at all. Or, like in my case, the app just isn't mature yet so there isn't a forgot password view.