### PR TITLE
Change from spread syntax to Object.assign

### DIFF
--- a/src/components/Presentation/FileUploadList.vue
+++ b/src/components/Presentation/FileUploadList.vue
@@ -10,7 +10,7 @@
           v-progress-circular(v-if="file.status === 'uploading'",
               color="primary",
               :rotate="-90",
-              :value="progressPercent({...file.progress, total: file.progress.size })",
+              :value="progressPercent(Object.assign({total: file.progress.size}, file.progress))",
               :indeterminate="file.progress.indeterminate")
           v-icon(v-if="file.status === 'done'", color="success", large) $vuetify.icons.complete
           v-icon(v-if="file.status === 'error'", color="error", large) $vuetify.icons.error


### PR DESCRIPTION
We had significant issues with vue-template-es2015-compiler versioning, that came down to (unsuccessfully) allowing spread syntax to work in this file.
Could we just change it to an Object.assign? Thanks!