### PR TITLE
Fix CI post-release tagging.

### DIFF
--- a/.circleci/git-config.sh
+++ b/.circleci/git-config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+git config user.name "$USER_NAME"
+git config user.email "$USER_EMAIL"
+
+# Remove strict host checking for github.com
+mkdir -p ~/.ssh/
+echo -e "Host github.com\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n" >> ~/.ssh/config
+chmod 600 ~/.ssh/config

--- a/.circleci/npmjs-publish.sh
+++ b/.circleci/npmjs-publish.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 set -o pipefail
+
+./.circleci/git-config.sh
+
 PACKAGE_VERSION=$(cat package.json \
   | grep version \
   | head -1 \
@@ -10,6 +13,11 @@ PACKAGE_VERSION=$(cat package.json \
 
 PUBLISHED_VERSION=$(npm show @girder/components version \
   | tr -d ' ')
+
+# Remove strict host checking for github.com
+mkdir -p ~/.ssh/
+echo -e "Host github.com\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n" >> ~/.ssh/config
+chmod 600 ~/.ssh/config
 
 if [ "$PACKAGE_VERSION" != "$PUBLISHED_VERSION" ]; then
   yarn publish --non-interactive

--- a/.circleci/npmjs-publish.sh
+++ b/.circleci/npmjs-publish.sh
@@ -14,11 +14,6 @@ PACKAGE_VERSION=$(cat package.json \
 PUBLISHED_VERSION=$(npm show @girder/components version \
   | tr -d ' ')
 
-# Remove strict host checking for github.com
-mkdir -p ~/.ssh/
-echo -e "Host github.com\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n" >> ~/.ssh/config
-chmod 600 ~/.ssh/config
-
 if [ "$PACKAGE_VERSION" != "$PUBLISHED_VERSION" ]; then
   yarn publish --non-interactive
   TAG_NAME="v${PACKAGE_VERSION}"

--- a/.circleci/pages-deploy.sh
+++ b/.circleci/pages-deploy.sh
@@ -1,10 +1,8 @@
-git config user.name "$USER_NAME"
-git config user.email "$USER_EMAIL"
+#!/bin/bash
+set -e
+set -o pipefail
 
-# Remove strict host checking for github.com
-mkdir -p ~/.ssh/
-echo -e "Host github.com\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n" >> ~/.ssh/config
-chmod 600 ~/.ssh/config
+./.circleci/git-config.sh
 
 git checkout gh-pages
 git pull origin gh-pages


### PR DESCRIPTION
npm deployment now works, which is nice.   

You'd think CircleCI would provide better mechanisms for this sort of thing.