### PR TITLE
possible fix

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -22,12 +22,17 @@ function setCookieFromAuth(auth) {
  */
 function setCookieFromHash(location) {
   const arr = location.hash.split(OauthTokenPrefix);
-  const token = arr[arr.length - 1].split(OauthTokenSuffix)[0];
-  if (token.length === GirderTokenLength) {
+  const tokenParts = arr[arr.length - 1].split(OauthTokenSuffix);
+  let token = null;
+  if (tokenParts.length >= 2) {
+    // Both the prefix and the suffix were present
+    [token] = tokenParts;
+    location.hash = location.hash.replace(`${OauthTokenPrefix}${token}${OauthTokenSuffix}`, '');
+  }
+  if (token !== null && token.length === GirderTokenLength) {
     const expires = new Date();
     expires.setDate((new Date()).getDate() + 365);
     setCookieFromAuth({ token, expires });
-    location.hash = location.hash.replace(`${OauthTokenPrefix}${token}${OauthTokenSuffix}`, '');
   }
   return token;
 }
@@ -49,7 +54,7 @@ export default class RestClient extends Vue {
    */
   constructor({
     apiRoot = '/api/v1',
-    token = cookies.get('girderToken') || setCookieFromHash(window.location),
+    token = setCookieFromHash(window.location) || cookies.get('girderToken'),
     axios = axios_.create(),
     useGirderAuthorizationHeader = false,
     setLocalCookie = true,


### PR DESCRIPTION
@zachmullen here's a possible fix that doesn't involve toggling the hash string.

It's based on the assumption that 
* your app being same-origin as girder is rare, so the default behavior should be to support cross-origin oauth
* Working out-of-the-box is better than feature toggle.

It simply swaps the order of how the token is obtained such that resetting the hash string is not conditional. 