### PR TITLE
Don't try to set cookie from hash during OAuth login

### DIFF
--- a/src/components/Authentication/Authentication.vue
+++ b/src/components/Authentication/Authentication.vue
@@ -16,7 +16,6 @@ v-card.girder-authentication-component
 <script>
 import GirderLogin from './Login.vue';
 import GirderRegistration from './Register.vue';
-import { OauthTokenPrefix, OauthTokenSuffix } from '../../rest';
 
 export default {
   inject: ['girderRest'],
@@ -34,6 +33,11 @@ export default {
     oauth: {
       type: Boolean,
       default: false,
+    },
+    /* Redirect URL for end of OAuth login flow. If not passed uses current URL. */
+    oauthRedirect: {
+      type: String,
+      default: null,
     },
     /* A full URL to be used as an anchor href to an external page. */
     forgotPasswordUrl: {
@@ -66,7 +70,7 @@ export default {
         try {
           return (await this.girderRest.get('oauth/provider', {
             params: {
-              redirect: `${window.location.href}${OauthTokenPrefix}{girderToken}${OauthTokenSuffix}`,
+              redirect: this.oauthRedirect || window.location.href,
               list: true,
             },
           })).data;

--- a/src/rest.js
+++ b/src/rest.js
@@ -3,10 +3,6 @@ import cookies from 'js-cookie';
 import { stringify } from 'qs';
 import Vue from 'vue';
 
-const GirderTokenLength = 64;
-export const OauthTokenPrefix = '#girderToken=';
-export const OauthTokenSuffix = '__';
-
 // Girder's custom headers
 const GirderToken = 'Girder-Token';
 const GirderOtp = 'Girder-OTP';
@@ -14,22 +10,6 @@ const GirderAuthorization = 'Girder-Authorization';
 
 function setCookieFromAuth(auth) {
   cookies.set('girderToken', auth.token, { expires: new Date(auth.expires) });
-}
-
-/**
- * set cookie if special string is found in the hash.
- * @param {Location} location
- */
-function setCookieFromHash(location) {
-  const arr = location.hash.split(OauthTokenPrefix);
-  const token = arr[arr.length - 1].split(OauthTokenSuffix)[0];
-  if (token.length === GirderTokenLength) {
-    const expires = new Date();
-    expires.setDate((new Date()).getDate() + 365);
-    setCookieFromAuth({ token, expires });
-    location.hash = location.hash.replace(`${OauthTokenPrefix}${token}${OauthTokenSuffix}`, '');
-  }
-  return token;
 }
 
 /**
@@ -49,7 +29,7 @@ export default class RestClient extends Vue {
    */
   constructor({
     apiRoot = '/api/v1',
-    token = cookies.get('girderToken') || setCookieFromHash(window.location),
+    token = cookies.get('girderToken'),
     axios = axios_.create(),
     useGirderAuthorizationHeader = false,
     setLocalCookie = true,


### PR DESCRIPTION
Fixes #188

This is a breaking change as it removes public symbols intentionally.