### PR TITLE
bugfix remove height 100%

### DIFF
--- a/src/components/Presentation/FileUploadList.vue
+++ b/src/components/Presentation/FileUploadList.vue
@@ -79,7 +79,6 @@ export default {
     height 0.8s ease-in-out 1s,
     background-color 0.5s ease-in-out;
   width: 100%;
-  height: 100%;
 
   &.status-uploading {
     background-color: #fef4c9;


### PR DESCRIPTION
Not sure why that was ever there in the first place.  Breaks everything when the height of the container is explicit.