### PR TITLE
Upload/mixin

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -38,7 +38,6 @@ import Dropzone from './Presentation/Dropzone.vue';
 import FileUploadList from './Presentation/FileUploadList.vue';
 import Upload from '../utils/upload';
 
-
 export default {
   components: {
     Dropzone,

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -14,7 +14,7 @@ v-card.fill-height(flat)
 
     v-card-actions(v-show="files.length && !errorMessage && !uploading")
       v-btn(text, @click="files = []") Clear all
-      v-btn(text, color="primary", @click="start") {{ startButtonText }}
+      v-btn(text, color="primary", @click="startUpload") {{ startButtonText }}
 
     v-col
       slot(name="dropzone")
@@ -26,7 +26,7 @@ v-card.fill-height(flat)
 
     div(v-if="errorMessage")
       v-alert(:value="true", dark, type="error") {{ errorMessage }}
-        v-btn(v-if="!uploading", dark, outlined, @click="start") Resume upload
+        v-btn(v-if="!uploading", dark, outlined, @click="startUpload") Resume upload
 
     slot(name="files", v-bind="{ files, setFiles, currentIndex, maxShow }")
       file-upload-list(@input="setFiles", v-bind="{ value: files, currentIndex, maxShow }")
@@ -96,6 +96,12 @@ export default {
           `(${this.totalProgressPercent}%)`;
       }
       return `${this.files.length} selected (${this.formatSize(this.totalSize)} total)`;
+    },
+  },
+  methods: {
+    startUpload() {
+      const { uploadCls, preUpload, postUpload } = this;
+      this.start({ uploadCls, preUpload, postUpload });
     },
   },
 };

--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -1,5 +1,5 @@
 import { AccessType } from '../constants';
-
+import Upload from './upload';
 /**
  * for components that need to show a locale-formatted date
  */
@@ -69,9 +69,151 @@ const usernameFormatter = {
   },
 };
 
+/**
+ * A mixin to allow components to maintan a list of files for upload.
+ * The consumer is responsible for how the file list is populated, but
+ * the helper methods `inputFilesChanged` and `setFiles` must be used
+ * rather than setting `this.files` directly.
+ */
+const fileUploader = {
+  inject: ['girderRest'],
+
+  data() {
+    return {
+      errorMessage: null,
+      files: [],
+      uploading: false,
+      currentIndex: 0,
+    };
+  },
+
+  watch: {
+    files(val) {
+      this.$emit('filesChanged', val);
+    },
+  },
+
+  computed: {
+    totalProgress() {
+      return this.files.reduce((v, f) => v + (f.progress.current), 0);
+    },
+    totalSize() {
+      return this.files.reduce((v, f) => v + f.file.size, 0);
+    },
+    totalProgressPercent() {
+      return this.progressPercent({
+        current: this.totalProgress,
+        total: this.totalSize,
+      });
+    },
+  },
+
+  methods: {
+    /**
+     * Populate the internal list of files from an HTML FileList
+     * @param {FileList} files from an input element
+     */
+    inputFilesChanged(files) {
+      this.currentIndex = 0;
+      this.files = files.map(file => ({
+        file,
+        status: 'pending',
+        progress: {
+          indeterminate: false,
+          current: 0,
+          size: file.size,
+        },
+        upload: null,
+        result: null,
+      }));
+    },
+
+    /**
+     * Set internal state from an array of existing file objects.
+     * Differs from `inputFileChanged` because the input array should already be a wrapped
+     * object array with the additional state added by that function.
+     * @param {Array<Object>} files new file list
+     */
+    setFiles(files) {
+      if (this.currentIndex >= files.length) {
+        this.currentIndex = files.length - 1;
+      }
+      this.files = files;
+    },
+
+    /**
+     * Begin uploading the current list of files.
+     */
+    async start({
+      preUpload = async () => {},
+      postUpload = async () => {},
+      uploadCls = Upload,
+    }) {
+      const results = [];
+      this.uploading = true;
+      this.errorMessage = null;
+      await preUpload();
+      for (; this.currentIndex < this.files.length; this.currentIndex += 1) {
+        const file = this.files[this.currentIndex];
+        if (file.status === 'done') {
+          // We are resuming, skip already completed files
+          results.push(file.result);
+        } else {
+          const progress = (event) => {
+            Object.assign(file.progress, event);
+          };
+          file.status = 'uploading';
+          file.progress.indeterminate = true;
+          try {
+            if (file.upload) {
+              // eslint-disable-next-line no-await-in-loop
+              file.result = await file.upload.resume();
+            } else {
+              // eslint-disable-next-line new-cap
+              file.upload = new uploadCls(file.file, {
+                $rest: this.girderRest,
+                parent: this.dest,
+                progress,
+              });
+              // eslint-disable-next-line no-await-in-loop
+              await file.upload.beforeUpload();
+              // eslint-disable-next-line no-await-in-loop
+              file.result = await file.upload.start();
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.afterUpload();
+            delete file.upload;
+            results.push(file.result);
+            file.status = 'done';
+            file.progress.current = file.file.size;
+          } catch (error) {
+            // eslint-disable-next-line no-await-in-loop
+            await file.upload.onError(error);
+
+            if (error.response) {
+              this.errorMessage = error.response.data.message || 'An error occurred during upload.';
+            } else {
+              this.errorMessage = 'Connection failed.';
+            }
+            file.status = 'error';
+            this.uploading = false;
+            this.$emit('error', { error, file });
+            return;
+          }
+        }
+      }
+      await postUpload();
+      this.uploading = false;
+      this.files = [];
+      this.$emit('done', results);
+    },
+  },
+};
+
 export {
   accessLevelChecker,
   dateFormatter,
+  fileUploader,
   progressReporter,
   sizeFormatter,
   usernameFormatter,


### PR DESCRIPTION
Not sure why it never occurred to me to do this before.

Extract upload mechanics into a mixin such that consumers can build their own uploaders without being constrained to the layout of the provided version.

Added some comments to explain the usage of the mixin.

There have been **no code/logic changes** aside from parameterizing the `start()` method to accept pre, post, and class.  This PR just moves the functions from one file to another.

I think a future PR should remove some of the fringe capabilities of the `Upload` component and instead just let a consumer write it themselves with this mixin.   for example, the dropzone slot is useless without slot props to access state.