### PR TITLE
Add props to control browser page size

### DIFF
--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -48,12 +48,20 @@ export default {
       type: Array,
       default: () => [],
     },
+    initialItemsPerPage: {
+      type: Number,
+      default: 10,
+    },
+    itemsPerPageOptions: {
+      type: Array,
+      default: () => ([5, 10, 15, -1]),
+    },
   },
 
   data() {
     return {
       options: {
-        itemsPerPage: 10,
+        itemsPerPage: this.initialItemsPerPage,
         page: 1,
       },
       internalRefreshCounter: 0,
@@ -308,6 +316,7 @@ girder-data-table.girder-file-browser(
     :draggable="draggable",
     :rows="rows",
     :options.sync="options",
+    :items-per-page-options="itemsPerPageOptions",
     :server-items-length="serverItemsLength",
     :loading="loading",
     :selectable="internalSelectable",

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -31,6 +31,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    itemsPerPageOptions: {
+      type: Array,
+      default: () => ([5, 10, 15, -1]),
+    },
   },
   data() {
     return { lastCheckBoxIdx: null };
@@ -74,6 +78,7 @@ v-data-table.girder-data-table(
     :value="value",
     @input="$emit('input', $event)",
     :options="options",
+    :footer-props="{'items-per-page-options': itemsPerPageOptions}",
     @update:options="$emit('update:options', $event)",
     :items="rows",
     :server-items-length="serverItemsLength",

--- a/src/components/Snippet/FileManager.vue
+++ b/src/components/Snippet/FileManager.vue
@@ -83,6 +83,14 @@ export default {
       type: Function,
       default: async () => {},
     },
+    initialItemsPerPage: {
+      type: Number,
+      default: 10,
+    },
+    itemsPerPageOptions: {
+      type: Array,
+      default: () => ([5, 10, 15, -1]),
+    },
   },
 
   inject: ['girderRest'],
@@ -198,7 +206,9 @@ v-card.girder-data-browser-snippet
       @drag="$emit('drag', $event)",
       @dragstart="$emit('dragstart', $event)",
       @dragend="$emit('dragend', $event)",
-      @drop="$emit('drop', $event)")
+      @drop="$emit('drop', $event)",
+      :initial-items-per-page="initialItemsPerPage",
+      :items-per-page-options="itemsPerPageOptions")
     template(#breadcrumb="props")
       girder-breadcrumb(
           :location="props.location",

--- a/tests/unit/DataBrowser.spec.js
+++ b/tests/unit/DataBrowser.spec.js
@@ -306,4 +306,42 @@ describe('DataBrowser', () => {
     expect(wrapper.vm.rows.length).toBe(1);
     expect(wrapper.vm.rows[0]._modelType).toBe('user');
   });
+
+  it('page size props', async () => {
+    mock.onGet(/folder\/fake_folder_id\/details/).reply(200, { nFolders: 12, nItems: 20 });
+    mock.onGet(/folder/, {
+      params: {
+        limit: 20,
+        offset: 0,
+        parentId: 'fake_folder_id',
+        parentType: 'folder',
+      },
+    }).replyOnce(200, getMockFolderQueryResponse(12));
+    mock.onGet('folder/fake_folder_id').replyOnce(200, getMockFolderResponse());
+
+    mock.onGet(/item/, {
+      params: {
+        limit: 8,
+        offset: 0,
+        folderId: 'fake_folder_id',
+      },
+    }).replyOnce(200, getMockItemQueryResponse(8));
+
+    const wrapper = shallowMount(DataBrowser, {
+      localVue,
+      vuetify,
+      propsData: {
+        location: {
+          _modelType: 'folder',
+          _id: 'fake_folder_id',
+        },
+        initialItemsPerPage: 20,
+        itemsPerPageOptions: [20, 30, 40, -1],
+      },
+      provide: { girderRest },
+    });
+    await flushPromises();
+    expect(wrapper.vm.rows.length).toBe(20);
+    expect(wrapper.find('girder-data-table-stub').props('itemsPerPageOptions')).toEqual([20, 30, 40, -1]);
+  });
 });


### PR DESCRIPTION
This is a feature requested by a downstream project https://github.com/dandi/dandiarchive/issues/42
It looks like a good feature to have to GWC. However, am not sure if the effort and (technical debt) to implement reactive itemsPerPage can be justified, so the itemsPerPage prop only controls initial size. 

I'll be adding a test case for it, any comment or feedback is welcomed. 