### PR TITLE
Fix issue that data browser don't handle page size 'all'

### DIFF
--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -33,7 +33,7 @@ export default {
     },
     itemsPerPageOptions: {
       type: Array,
-      default: () => ([5, 10, 15, -1]),
+      default: () => ([10, 25, 50]),
     },
   },
   data() {

--- a/src/components/Snippet/FileManager.vue
+++ b/src/components/Snippet/FileManager.vue
@@ -89,7 +89,7 @@ export default {
     },
     itemsPerPageOptions: {
       type: Array,
-      default: () => ([5, 10, 15, -1]),
+      default: () => ([10, 25, 50]),
     },
   },
 

--- a/tests/unit/DataBrowser.spec.js
+++ b/tests/unit/DataBrowser.spec.js
@@ -181,14 +181,14 @@ describe('DataBrowser', () => {
     mock.onGet(/folder\/fake_folder_id\/details/).reply(200, { nFolders: 12, nItems: 20 });
     mock.onGet(/item/, {
       params: {
-        limit: null,
+        limit: 0,
         offset: 0,
         folderId: 'fake_folder_id',
       },
     }).replyOnce(200, getMockItemQueryResponse(20));
     mock.onGet(/folder/, {
       params: {
-        limit: null,
+        limit: 0,
         offset: 0,
         parentId: 'fake_folder_id',
         parentType: 'folder',
@@ -336,12 +336,12 @@ describe('DataBrowser', () => {
           _id: 'fake_folder_id',
         },
         initialItemsPerPage: 20,
-        itemsPerPageOptions: [20, 30, 40, -1],
+        itemsPerPageOptions: [20, 30, 40],
       },
       provide: { girderRest },
     });
     await flushPromises();
     expect(wrapper.vm.rows.length).toBe(20);
-    expect(wrapper.find('girder-data-table-stub').props('itemsPerPageOptions')).toEqual([20, 30, 40, -1]);
+    expect(wrapper.find('girder-data-table-stub').props('itemsPerPageOptions')).toEqual([20, 30, 40]);
   });
 });


### PR DESCRIPTION
While I was trying to add support for 'all' page size. 
I noticed that the browser makes unnecessary requests to folder or items under certain conditions, so I refactored the code to handle those conditions.

This PR also update default page sizes.

Resolve https://github.com/girder/girder_web_components/issues/205