### PR TITLE
Make dest a param of upload.start

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -99,8 +99,12 @@ export default {
   },
   methods: {
     startUpload() {
-      const { uploadCls, preUpload, postUpload } = this;
-      this.start({ uploadCls, preUpload, postUpload });
+      const {
+        dest, uploadCls, preUpload, postUpload,
+      } = this;
+      this.start({
+        dest, uploadCls, preUpload, postUpload,
+      });
     },
   },
 };

--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -145,6 +145,7 @@ const fileUploader = {
      * Begin uploading the current list of files.
      */
     async start({
+      dest,
       preUpload = async () => {},
       postUpload = async () => {},
       uploadCls = Upload,
@@ -172,7 +173,7 @@ const fileUploader = {
               // eslint-disable-next-line new-cap
               file.upload = new uploadCls(file.file, {
                 $rest: this.girderRest,
-                parent: this.dest,
+                parent: dest,
                 progress,
               });
               // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
in #200 I made upload functionality into a mixin and factored `upload.start()`'s parameters from instance properties into explicit function properties.  I overlooked `dest`.

This had the interesting effect of allowing the `preUpload` function to set dest.  While I think that's a good capability, it relies on the developer knowing a little too much about the reactivity system and the JS event loop for my liking.  If `dest`  is a prop of the upload component and is modified during `preUpload` it's hard to reason about the race between the dest update and the `start` func arriving at this block:

```js
file.upload = new uploadCls(file.file, {
                $rest: this.girderRest,
                parent: this.dest,
                progress,
              });
```

TL;DR; there's too many moving parts for a developer to be confident that `dest` will win the race condition every time, so I've made it an explicit param of the function.

If it turns out that it's useful/common for `preUpload` to set dest, we should document it as the return type for preUpload.  Otherwise, I think the below code is sufficient for most use cases

```js
const dest = await this.preUpload();
  this.$refs.uploader.start({
    dest,
    postUpload: this.postUpload,
  });
```