### PR TITLE
Add an additional slot to DataTable

### DIFF
--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -339,4 +339,6 @@ girder-data-table.girder-file-browser(
           slot(name="breadcrumb", v-bind="{ location, changeLocation, rootLocationDisabled }")
           v-spacer
           slot(name="headerwidget", v-bind="{ location, changeLocation, rootLocationDisabled }")
+  template(#row-widget="props")
+    slot(name="row-widget", v-bind="props")
 </template>

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -107,6 +107,7 @@ v-data-table.girder-data-table(
           v-icon.pr-2(:color="props.isSelected ? 'accent' : ''")
             | {{ $vuetify.icons.values[props.item.icon] }}
           | {{ props.item.name }}
+          slot(name="row-widget", v-bind="props")
       td.text-right.nobreak {{ props.item.humanSize }}
 
   template(#no-data="")

--- a/src/components/Snippet/FileManager.vue
+++ b/src/components/Snippet/FileManager.vue
@@ -249,6 +249,8 @@ v-card.girder-data-browser-snippet
             :post-upsert="postUpsertInternal",
             :key="internalLocation._id",
             @dismiss="newFolderDialog = false")
+    template(#row-widget="props")
+      slot(name="row-widget", v-bind="props")
   v-menu(
       v-model="collectionAndFolderMenu.show",
       :position-x="collectionAndFolderMenu.x",


### PR DESCRIPTION
This would allow the use of DataTable in a more customized way like this
![image](https://user-images.githubusercontent.com/3123478/71276076-99896500-2322-11ea-96db-2ea9953ec300.png)
Specifically, there is a downstream project that needs to distinguish folder navigation and opening the video clip within the folder. 