### PR TITLE
upgrade to vuetify 2.2.4

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -50,6 +50,7 @@ v-app.app
               v-if="browserEnabled",
               ref="girderFileManager",
               v-model="selected",
+              :items-per-page-options="[10, 20, -1]",
               :drag-enabled="dragEnabled",
               :new-folder-enabled="newFolderEnabled",
               :selectable="selectable",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "qs": "^6.5.2",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.4.1",
-    "vuetify": "^2.1.10"
+    "vuetify": "^2.2.4"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -324,21 +324,21 @@ girder-data-table.girder-file-browser(
     @dragstart="$emit('dragstart', $event)",
     @dragend="$emit('dragend', $event)",
     @drop="$emit('drop', $event)")
-
   template(#header="{ props, on }")
-    tr.secondary(:class="$vuetify.theme.dark?'darken-2':'lighten-5'")
-      th.pl-3.pr-0(width="1%", v-if="internalSelectable")
-        v-checkbox.pr-2(
-            color="accent",
-            hide-details,
-            :input-value="props.everyItem",
-            :indeterminate="internalValue.length > 0 && !props.everyItem",
-            @click.native="on['toggle-select-all'](!props.everyItem)")
-      th.pl-3(colspan="10", width="99%")
-        v-row.ma-1
-          slot(name="breadcrumb", v-bind="{ location, changeLocation, rootLocationDisabled }")
-          v-spacer
-          slot(name="headerwidget", v-bind="{ location, changeLocation, rootLocationDisabled }")
+    thead
+      tr.secondary(:class="$vuetify.theme.dark?'darken-2':'lighten-5'")
+        th.pl-3.pr-0(width="1%", v-if="internalSelectable")
+          v-checkbox.pr-2(
+              color="accent",
+              hide-details,
+              :input-value="props.everyItem",
+              :indeterminate="internalValue.length > 0 && !props.everyItem",
+              @click.native="on['toggle-select-all'](!props.everyItem)")
+        th.pl-3(colspan="10", width="99%")
+          v-row.ma-1
+            slot(name="breadcrumb", v-bind="{ location, changeLocation, rootLocationDisabled }")
+            v-spacer
+            slot(name="headerwidget", v-bind="{ location, changeLocation, rootLocationDisabled }")
   template(#row-widget="props")
     slot(name="row-widget", v-bind="props")
 </template>

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -74,6 +74,7 @@ export default {
 <template lang="pug">
 v-data-table.girder-data-table(
     show-select,
+    hide-default-header,
     :headers-length="4",
     :value="value",
     @input="$emit('input', $event)",

--- a/src/utils/vuetifyConfig.js
+++ b/src/utils/vuetifyConfig.js
@@ -15,15 +15,15 @@ export default {
     themes: {
       light: {
         primary: colors.lightBlue.darken1,
-        secondary: colors.blueGrey,
+        secondary: colors.blueGrey.base,
         accent: colors.lightBlue.darken1,
-        error: colors.red,
+        error: colors.red.base,
         info: colors.lightBlue.lighten1,
         dropzone: colors.grey.lighten3,
       },
       dark: {
         primary: colors.lightBlue.darken3,
-        secondary: colors.grey,
+        secondary: colors.grey.base,
         accent: colors.lightBlue.lighten1,
         dropzone: colors.grey.darken2,
       },

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
+import Vuetify from 'vuetify/lib';
 import vuetifyConfig from '@/utils/vuetifyConfig';
 import { createLocalVue } from '@vue/test-utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11612,10 +11612,10 @@ vuetify-loader@^1.3.0:
   dependencies:
     loader-utils "^1.2.0"
 
-vuetify@^2.1.10:
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.1.10.tgz#ff2107bf1a5f227b18dbe31e08d92753ad68a15b"
-  integrity sha512-hFc6XNYc2YE3HisxCH5VezRFtGQ2RwTvBy7eN+b67UuiGIhvEUR9h3uO4NUuulmvKPKJ4rONN+L9sVszgMBlJQ==
+vuetify@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.2.4.tgz#3f82cb1694a306aac7c88bda815ad812df555bf9"
+  integrity sha512-jhSdCeatWgHrY4Bb2FTi1sFfGDrVHLmkvI7pkG9FEF9TmZ+Qq7Ts85XAft9ucwU8ybB5nDmN6s+oeHJgvL+4tA==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I feel like every successive update turns vuetify into a more and more quirky codebase, and I'm really starting to wonder if they've just lost control of the scope of the project and the organization is insufficient for the complexity they're managing.

I talked to Jared for a while and we are both really disappointed by the rigidity and high cognitive load of the v-row and v-col grid system compared to v-container and v-layout.  I'm about 1 free afternoon away from trying to replicate the 1.X v-container and v-layout components clean-room style in pure flexbox CSS.  Prepare yourselves for girder-container and girder-layout.

I also don't know how it makes sense that, if I specify a slot for the header, I also have to remember to disable the default header or else I get 2 headers.  That's not a sane default.

/rant

Upgrades to Vuetify 2.2.4

cc @HastingsGreer: I was not able to reproduce your error within the demo app with this upgrade.  This PR will, however, make your downgrade impossible.  So we'd have to get to the bottom of that issue.

EDIT: I'm actually able to reproduce it in the unit tests.  Fix hopefully incoming.