### PR TITLE
Interactive documentation

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -4,8 +4,13 @@ v-app.app
     v-container
       v-col(xl=8, offset-xl=2, lg=10, offset-lg=1, md=12, offset-md=0)
         .display-3 Girder Web Components
-        .title.mb-1 A Vue + Vuetify library for interacting with Kitware's
-          | data management platform, Girder
+        .title.mb-1 A Vue + Vuetify library
+          |  for interacting with
+          |
+          a(href="https://www.kitware.com/") Kitware's
+          |  data management platform,
+          |
+          a(href="https://girder.readthedocs.io/en/stable/") Girder
 
         img.pr-3(v-for="badge in badges", :key="badge", :src="badge")
 

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -4,20 +4,23 @@ v-app.app
     v-container
       v-col(xl=8, offset-xl=2, lg=10, offset-lg=1, md=12, offset-md=0)
         .display-3 Girder Web Components
-        .title.mb-1 A Vue + Vuetify library
-          |  for interacting with
-          |
-          a(href="https://www.kitware.com/") Kitware's
-          |  data management platform,
-          |
-          a(href="https://girder.readthedocs.io/en/stable/") Girder
+        .title.mb-1.
+          A Vue + Vuetify library for interacting with
+          #[a(href="https://www.kitware.com/") Kitware's]
+          data management platform,
+          #[a(href="https://girder.readthedocs.io/en/stable/") Girder]
 
         img.pr-3(v-for="badge in badges", :key="badge", :src="badge")
 
-        v-switch.mt-1.mb-1(
-            hide-details,
-            label="Dark theme",
-            v-model="$vuetify.theme.dark")
+        v-row.ma-0
+          .title.mb-1.
+            This demo integrates with
+            #[a(href="https://data.kitware.com") data.kitware.com]
+
+          v-switch.mx-4.my-0(
+              hide-details,
+              label="Dark theme",
+              v-model="$vuetify.theme.dark")
 
         headline(
             title="girder-auth",
@@ -57,18 +60,19 @@ v-app.app
           girder-search(@select="handleSearchSelect")
 
         v-row
-          v-col(lg=8, md=6, sm=12)
+          v-col.pr-4(xl=8, lg=8, md=6, sm=12)
             headline(
                 title="girder-file-manager",
                 link="src/components/Snippet/FileManager.vue",
-                description="provides a wrapper around girder-data-browser.\
+                description="a wrapper around girder-data-browser.\
                   It packages the browser with defaults including folder creation, item upload,\
                   and a breadcrumb bar")
-          v-col
+          v-col.pa-0
             headline(
                 title="girder-data-details",
                 link="src/components/DataDetails.vue",
-                description="provides in-depth information about a single folder or item.")
+                description="in-depth information and controls for a single\
+                  folder or item, or batch operations for groups of objects.")
         v-row
           v-switch.ma-2(hide-details, label="Select", v-model="selectable")
           v-switch.ma-2(hide-details, label="Draggable", v-model="dragEnabled")
@@ -79,7 +83,7 @@ v-app.app
               label="Root Disabled",
               v-model="rootLocationDisabled")
         v-row
-          v-col(lg=8, md=6, sm=12)
+          v-col.pr-4(lg=8, md=6, sm=12)
             girder-file-manager(
                 ref="girderFileManager",
                 v-model="selected",
@@ -91,7 +95,7 @@ v-app.app
                 :root-location-disabled="rootLocationDisabled",
                 :upload-multiple="uploadMultiple",
                 :upload-enabled="uploadEnabled")
-          v-col
+          v-col.pl-0(lg=4, md=6, sm=12)
             girder-data-details(:value="detailsList", @action="handleAction")
 
         headline(
@@ -186,7 +190,10 @@ export default {
     location: {
       get() {
         return this.internalLocation || (
-          this.loggedOut ? { type: 'collections' } : this.girderRest.user
+          this.loggedOut ? {
+            _id: '5c8a72438d777f072b97f9e1',
+            _modelType: 'folder',
+          } : this.girderRest.user
         );
       },
       set(value) {

--- a/demo/Headline.vue
+++ b/demo/Headline.vue
@@ -1,0 +1,36 @@
+<script>
+const repoBase = 'https://github.com/girder/girder_web_components/blob/master/';
+
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    link: {
+      type: String,
+      required: true,
+    },
+  },
+  data: () => ({ repoBase }),
+};
+</script>
+
+<template lang="pug">
+  div
+    .headline.font-weight-bold.mono.mt-8
+      | {{ title }}
+      v-btn.ma-1(icon, :href="repoBase + link")
+        v-icon $vuetify.icons.externalLink
+    .subtitle-1.mb-4 {{ description }}
+</template>
+
+<style scoped>
+.mono {
+  font-family: "Lucida Console", Monaco, monospace !important;
+}
+</style>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,7 +6,7 @@ import Authentication from './Authentication/';
 import Breadcrumb from './Breadcrumb.vue';
 import DataBrowser from './DataBrowser.vue';
 import DataDetails from './DataDetails.vue';
-import job from './Job/';
+import job from './Job';
 import Markdown from './Markdown.vue';
 import MarkdownEditor from './MarkdownEditor.vue';
 import Search from './Search.vue';

--- a/src/utils/vuetifyConfig.js
+++ b/src/utils/vuetifyConfig.js
@@ -40,6 +40,7 @@ export default {
       collection: 'mdi-file-tree',
       download: 'mdi-download',
       edit: 'mdi-pencil',
+      externalLink: 'mdi-open-in-new',
       file: 'mdi-file',
       fileMultiple: 'mdi-file-multiple',
       fileNew: 'mdi-file-plus',


### PR DESCRIPTION
This PR makes changes to the demo application.

I've found recently that when trying to explain girder web components, showing people the demo, which looks like a normal application, is confusing.  It's hard to explain to someone who isn't already a Vue developer what the "components" are and how they could be useful within your application.

I've also found that people are confused about what exactly this package offers.  Is it just a login box and the data browser? 

This PR seeks to make the demo app less of a "sample implementation" and more like interactive documentation. I'm really fond of what Vuetify has done, and that's the spirit of what I'm trying here.

![Screenshot from 2020-01-23 15-32-43](https://user-images.githubusercontent.com/4214172/73022069-d8fe1200-3df6-11ea-9219-e39031e33d61.png)

I'm not done yet, and I didn't want to spend long on this (took about an hour), but hopefully this gives you an idea.

My end goal is:

1) a full enumeration of the top-level components with descriptions.
2) a couple of knobs for each one, showing some common toggles.
3) links to each component's code, so that the demo page can essentially be used as a reference when "I can't remember what props girder-upload takes"
4) include the npm/yarn install commands so the demo page looks more like a real library's landing page.  

Thoughts, @zachmullen and @jeffbaumes ?