### PR TITLE
Hide the upload button if `startButtonText` is blank

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -18,7 +18,7 @@ v-card.fill-height(flat)
 
     v-card-actions(v-show="files.length && !errorMessage && !uploading")
       v-btn(text, @click="reset") Clear all
-      v-btn(text, color="primary", @click="startUpload") {{ startButtonText }}
+      v-btn(v-if="startButtonText.length > 0", text, color="primary", @click="startUpload") {{ startButtonText }}
 
     v-col
       slot(name="dropzone")


### PR DESCRIPTION
I've got a situation where I'd like to prevent the user from clicking on the stock "start upload" button, and I thought it would be neat if simply specifying a blank string as the button text would cause it not to be rendered at all.