### PR TITLE
Remove unnecessary import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,7 @@ yarn add -D sass sass-loader@^7.3.1 vue-cli-plugin-vuetify vuetify-loader
 ```
 
 > **Note:** If you are building with custom webpack (without vue-cli-service),
-> add the following to your module rules in webpack.config.js:
->
-> ```javascript
-> {
->   test: /\.(sass|scss)$/,
->   use: [
->       "style-loader",
->       "css-loader",
->       "sass-loader",
->   ],
-> },
-> ```
+> you should follow Vuetify's [Webpack install instructions](https://vuetifyjs.com/en/getting-started/quick-start/#webpack-install)
 
 ### Initialization
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,4 @@
 import '@mdi/font/css/materialdesignicons.min.css';
-import 'vuetify/dist/vuetify.min.css';
 
 import AccessControl from './AccessControl.vue';
 import Authentication from './Authentication/';


### PR DESCRIPTION
Because we're using vuetify-loader now, that import was unnecessary.  If a consumer wants to use this without vuetify-loader, importing the stylesheet will be their problem.

