### PR TITLE
Autoformatting with js-beautify-html

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "vetur.format.defaultFormatter.js": "none",
+  "vetur.format.defaultFormatter.html": "js-beautify-html",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+}

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -4,34 +4,44 @@
       <v-list>
         <nav-link
           class="mb-1 font-weight-bold"
-          title="Components"/>
+          title="Components"
+        />
         <nav-link
           title="Authentication"
-          href="#auth"/>
+          href="#auth"
+        />
         <nav-link
           title="Upload"
-          href="#upload"/>
+          href="#upload"
+        />
         <nav-link
           title="Search"
-          href="#search"/>
+          href="#search"
+        />
         <nav-link
           title="File manager"
-          href="#file-manager"/>
+          href="#file-manager"
+        />
         <nav-link
           title="Data details"
-          href="#data-details"/>
+          href="#data-details"
+        />
         <nav-link
           title="Job list"
-          href="#job-list"/>
+          href="#job-list"
+        />
         <nav-link
           title="Access control"
-          href="#access-control"/>
+          href="#access-control"
+        />
         <nav-link
           title="Add / edit folder"
-          href="#upsert-folder"/>
+          href="#upsert-folder"
+        />
         <nav-link
           title="Breadcrumb"
-          href="#breadcrumb"/>
+          href="#breadcrumb"
+        />
       </v-list>
     </v-navigation-drawer>
     <v-content>
@@ -42,7 +52,8 @@
           lg="10"
           offset-lg="1"
           md="12"
-          offset-md="0">
+          offset-md="0"
+        >
           <div class="display-3">Girder Web Components</div>
           <div class="title mb-1">A Vue + Vuetify library for interacting with
             <a href="https://www.kitware.com/">Kitware's</a>
@@ -52,7 +63,8 @@
             v-for="badge in badges"
             :key="badge"
             :src="badge"
-            class="pr-3" >
+            class="pr-3"
+          >
           <v-row class="ma-0">
             <div class="title mb-1">This demo integrates with
               <a href="https://data.kitware.com">data.kitware.com</a>
@@ -61,53 +73,62 @@
               v-model="$vuetify.theme.dark"
               class="mx-4 my-0"
               hide-details="hide-details"
-              label="Dark theme"/>
-          </v-row><a id="auth"/>
+              label="Dark theme"
+            />
+          </v-row><a id="auth" />
           <headline
             title="girder-auth"
             link="src/components/Authentication/Authentication.vue"
-            description="allows users to authenticate with girder"/>
+            description="allows users to authenticate with girder"
+          />
           <v-row class="mb-2">
             <v-switch
               v-model="authRegister"
               class="ma-2"
               hide-details="hide-details"
-              label="register"/>
+              label="register"
+            />
             <v-switch
               v-model="authOauth"
               class="ma-2"
               hide-details="hide-details"
-              label="oauth"/>
+              label="oauth"
+            />
           </v-row><template v-if="loggedOut">
             <girder-auth
               :force-otp="false"
               :register="authRegister"
               :oauth="authOauth"
               :key="girderRest.token"
-              :forgot-password-url="forgotPasswordUrl"/>
+              :forgot-password-url="forgotPasswordUrl"
+            />
           </template><template v-else>
             <v-btn
               v-if="!loggedOut"
               color="primary"
-              @click="girderRest.logout()">Log Out
+              @click="girderRest.logout()"
+            >Log Out
               <v-icon class="pl-2">$vuetify.icons.logout</v-icon>
             </v-btn>
-          </template><a id="upload"/>
+          </template><a id="upload" />
           <headline
             title="girder-upload"
             link="src/components/Upload.vue"
-            description="upload files to a specified location in girder"/>
+            description="upload files to a specified location in girder"
+          />
           <v-card>
             <girder-upload
               :dest="uploadDest"
-              :post-upload="postUpload"/>
-          </v-card><a id="search"/>
+              :post-upload="postUpload"
+            />
+          </v-card><a id="search" />
           <headline
             title="girder-search"
             link="src/components/Search.vue"
-            description="provides global search functionality"/>
+            description="provides global search functionality"
+          />
           <v-toolbar color="primary">
-            <girder-search @select="handleSearchSelect"/>
+            <girder-search @select="handleSearchSelect" />
           </v-toolbar>
           <v-row>
             <v-col
@@ -115,19 +136,22 @@
               xl="8"
               lg="8"
               md="6"
-              sm="12"><a id="file-manager"/>
+              sm="12"
+            ><a id="file-manager" />
               <headline
                 title="girder-file-manager"
                 link="src/components/Snippet/FileManager.vue"
                 description="a wrapper around girder-data-browser. It packages the browser with
-                defaults including folder creation, item upload, and a breadcrumb bar"/>
+                defaults including folder creation, item upload, and a breadcrumb bar"
+              />
             </v-col>
-            <v-col class="pa-0"><a id="data-details"/>
+            <v-col class="pa-0"><a id="data-details" />
               <headline
                 title="girder-data-details"
                 link="src/components/DataDetails.vue"
                 description="in-depth information and controls for a single folder or item, or
-                batch operations for groups of objects."/>
+                batch operations for groups of objects."
+              />
             </v-col>
           </v-row>
           <v-row>
@@ -135,34 +159,40 @@
               v-model="selectable"
               class="ma-2"
               hide-details="hide-details"
-              label="Select"/>
+              label="Select"
+            />
             <v-switch
               v-model="dragEnabled"
               class="ma-2"
               hide-details="hide-details"
-              label="Draggable"/>
+              label="Draggable"
+            />
             <v-switch
               v-model="newFolderEnabled"
               class="ma-2"
               hide-details="hide-details"
-              label="New Folder"/>
+              label="New Folder"
+            />
             <v-switch
               v-model="uploadEnabled"
               class="ma-2"
               hide-details="hide-details"
-              label="Upload"/>
+              label="Upload"
+            />
             <v-switch
               v-model="rootLocationDisabled"
               class="mt-2"
               hide-details="hide-details"
-              label="Root Disabled"/>
+              label="Root Disabled"
+            />
           </v-row>
           <v-row>
             <v-col
               class="pr-4"
               lg="8"
               md="6"
-              sm="12">
+              sm="12"
+            >
               <girder-file-manager
                 ref="girderFileManager"
                 v-model="selected"
@@ -173,46 +203,55 @@
                 :location.sync="location"
                 :root-location-disabled="rootLocationDisabled"
                 :upload-multiple="uploadMultiple"
-                :upload-enabled="uploadEnabled"/>
+                :upload-enabled="uploadEnabled"
+              />
             </v-col>
             <v-col
               class="pl-0"
               lg="4"
               md="6"
-              sm="12">
+              sm="12"
+            >
               <girder-data-details
                 :value="detailsList"
-                @action="handleAction"/>
+                @action="handleAction"
+              />
             </v-col>
-          </v-row><a id="job-list"/>
+          </v-row><a id="job-list" />
           <headline
             title="girder-job-list"
             link="src/components/Job/JobList.vue"
-            description="display and filter girder jobs"/>
-          <girder-job-list/><a id="access-control"/>
+            description="display and filter girder jobs"
+          />
+          <girder-job-list /><a id="access-control" />
           <headline
             title="girder-access-control"
             link="src/components/AccessControl.vue"
-            description="access controls for folders and items"/>
-          <girder-access-control :model="uploadDest"/><a id="upsert-folder"/>
+            description="access controls for folders and items"
+          />
+          <girder-access-control :model="uploadDest" /><a id="upsert-folder" />
           <headline
             title="girder-upsert-folder"
             link="src/components/UpsertFolder.vue"
-            description="create and edit folders"/>
+            description="create and edit folders"
+          />
           <v-switch
             v-model="upsertEdit"
-            label="Edit Mode"/>
+            label="Edit Mode"
+          />
           <v-card>
             <girder-upsert-folder
               :location="uploadDest"
-              :edit="upsertEdit"/>
-          </v-card><a id="breadcrumb"/>
+              :edit="upsertEdit"
+            />
+          </v-card><a id="breadcrumb" />
           <headline
             title="girder-breadcrumb"
             link="src/components/Breadcrumb.vue"
-            description="filesystem path breadcrumb"/>
+            description="filesystem path breadcrumb"
+          />
           <v-card class="pa-4">
-            <girder-breadcrumb :location="uploadDest"/>
+            <girder-breadcrumb :location="uploadDest" />
           </v-card>
         </v-col>
       </v-container>

--- a/demo/Headline.vue
+++ b/demo/Headline.vue
@@ -27,7 +27,8 @@ export default {
         :href="repoBase + link"
         class="ml-2"
         icon="icon"
-        title="View source">
+        title="View source"
+      >
         <v-icon>$vuetify.icons.externalLink</v-icon>
       </v-btn>
     </div>

--- a/demo/NavLink.vue
+++ b/demo/NavLink.vue
@@ -25,7 +25,8 @@ export default {
   <v-list-item
     :link="!!href"
     :href="href"
-    v-on="listeners">
+    v-on="listeners"
+  >
     <v-list-item-content>
       <v-list-item-title>{{ title }}</v-list-item-title>
     </v-list-item-content>

--- a/src/components/AccessControl.vue
+++ b/src/components/AccessControl.vue
@@ -155,7 +155,8 @@ export default {
         <breadcrumb
           :location="model"
           readonly="readonly"
-          no-root="no-root"/>
+          no-root="no-root"
+        />
       </div>
     </v-card-title>
     <v-card-text class="pt-0">
@@ -164,19 +165,23 @@ export default {
         :hint="publicText"
         class="mb-4"
         label="Public"
-        persistent-hint="persistent-hint"/>
+        persistent-hint="persistent-hint"
+      />
       <v-subheader>Users / Groups</v-subheader>
       <transition
         name="height"
-        mode="out-in">
+        mode="out-in"
+      >
         <v-list
           v-if="groupsAndUsers.length"
           class="group-user"
-          two-line="two-line">
+          two-line="two-line"
+        >
           <transition-group name="height2">
             <v-list-item
               v-for="model of groupsAndUsers"
-              :key="model.id">
+              :key="model.id"
+            >
               <v-list-item-action class="mr-5">
                 <v-icon>{{ $vuetify.icons.values[model.login?'user':'group'] }}</v-icon>
               </v-list-item-action>
@@ -192,12 +197,14 @@ export default {
                   light="light"
                   solo="solo"
                   hide-details="hide-details"
-                  dense="dense"/>
+                  dense="dense"
+                />
               </v-list-item-action>
               <v-list-item-action class="mr-5">
                 <v-btn
                   icon="icon"
-                  @click="remove(model)">
+                  @click="remove(model)"
+                >
                   <v-icon>mdi-minus-circle</v-icon>
                 </v-btn>
               </v-list-item-action>
@@ -206,7 +213,8 @@ export default {
         </v-list>
         <div
           v-if="!groupsAndUsers.length && !loading"
-          class="mt-1 mb-2">Empty</div>
+          class="mt-1 mb-2"
+        >Empty</div>
       </transition>
       <v-subheader>Grant access</v-subheader>
       <search
@@ -215,26 +223,31 @@ export default {
         class="search mb-3"
         hide-search-icon="hide-search-icon"
         placeholder="User or group name"
-        @select="groupOrUserSelected"/>
+        @select="groupOrUserSelected"
+      />
       <v-switch
         v-model="recursive"
         :hint="recursiveText"
         class="mt-0"
         label="Include subfolders"
-        persistent-hint="persistent-hint"/>
+        persistent-hint="persistent-hint"
+      />
     </v-card-text>
     <slot
       v-bind="{ save, loading }"
-      name="card-actions">
+      name="card-actions"
+    >
       <v-card-actions>
-        <v-spacer/>
+        <v-spacer />
         <v-btn
           text="text"
-          @click="$emit('close')">Cancel</v-btn>
+          @click="$emit('close')"
+        >Cancel</v-btn>
         <v-btn
           color="primary"
           depressed="depressed"
-          @click="save">Save</v-btn>
+          @click="save"
+        >Save</v-btn>
       </v-card-actions>
     </slot>
   </v-card>

--- a/src/components/Authentication/Authentication.vue
+++ b/src/components/Authentication/Authentication.vue
@@ -3,24 +3,28 @@
     <v-tabs
       v-model="activeTab"
       background-color="primary"
-      dark="dark">
-      <v-tabs-slider color="yellow"/>
+      dark="dark"
+    >
+      <v-tabs-slider color="yellow" />
       <v-tab key="login">Log In</v-tab>
       <v-tab
         v-if="register"
-        key="registration">Register</v-tab>
+        key="registration"
+      >Register</v-tab>
     </v-tabs>
     <v-tabs-items v-model="activeTab">
       <v-tab-item key="login-box">
         <girder-login
           :oauth-providers="oauthProviders"
           v-bind="{ forceOtp, forgotPasswordUrl, forgotPasswordRoute, hideForgotPassword }"
-          @forgotpassword="$emit('forgotpassword')"/>
+          @forgotpassword="$emit('forgotpassword')"
+        />
       </v-tab-item>
       <v-tab-item
         v-if="register"
-        key="registration-box">
-        <girder-registration :oauth-providers="oauthProviders"/>
+        key="registration-box"
+      >
+        <girder-registration :oauth-providers="oauthProviders" />
       </v-tab-item>
     </v-tabs-items>
   </v-card>
@@ -77,12 +81,14 @@ export default {
     async oauthProviders() {
       if (this.oauth) {
         try {
-          return (await this.girderRest.get('oauth/provider', {
-            params: {
-              redirect: `${window.location.href}${OauthTokenPrefix}{girderToken}${OauthTokenSuffix}`,
-              list: true,
-            },
-          })).data;
+          return (
+            await this.girderRest.get('oauth/provider', {
+              params: {
+                redirect: `${window.location.href}${OauthTokenPrefix}{girderToken}${OauthTokenSuffix}`,
+                list: true,
+              },
+            })
+          ).data;
         } catch (e) {
           return [];
         }

--- a/src/components/Authentication/Login.vue
+++ b/src/components/Authentication/Login.vue
@@ -7,11 +7,13 @@
       class="mt-0"
       dismissible="dismissible"
       transition="scale-transition"
-      type="error">{{ err }}</v-alert>
+      type="error"
+    >{{ err }}</v-alert>
     <v-container>
       <v-form
         ref="login"
-        @submit.prevent="login">
+        @submit.prevent="login"
+      >
         <v-text-field
           v-if="!otpFormVisible || forceOtp"
           v-model="username"
@@ -19,44 +21,49 @@
           label="Username or e-mail"
           autofocus="autofocus"
           prepend-icon="$vuetify.icons.user"
-          type="text"/>
+          type="text"
+        />
         <v-text-field
           v-if="!otpFormVisible || forceOtp"
           v-model="password"
           :rules="nonEmptyRules"
           type="password"
           label="Password"
-          prepend-icon="$vuetify.icons.lock"/>
+          prepend-icon="$vuetify.icons.lock"
+        />
         <v-text-field
           v-if="otpFormVisible || forceOtp"
           v-model="otp"
           :rules="otpRules"
           type="text"
           label="Authentication code"
-          prepend-icon="$vuetify.icons.otp"/>
+          prepend-icon="$vuetify.icons.otp"
+        />
         <v-card-actions>
           <v-btn
             :disabled="inProgress"
             :loading="inProgress"
             class="ml-0"
             type="submit"
-            color="primary">
+            color="primary"
+          >
             <v-icon left="left">$vuetify.icons.login</v-icon>
             {{ otpFormVisible ? 'Verify code' : 'Login' }}
           </v-btn><template v-if="!hideForgotPassword">
-            <v-spacer/>
+            <v-spacer />
             <v-btn
               :to="forgotPasswordRoute"
               :href="forgotPasswordUrl"
               text="text"
               color="primary"
-              @click="$emit('forgotpassword')">Forgot Password?</v-btn>
+              @click="$emit('forgotpassword')"
+            >Forgot Password?</v-btn>
           </template>
         </v-card-actions>
       </v-form>
     </v-container><template v-if="oauthProviders && oauthProviders.length">
-      <v-divider/>
-      <girder-oauth :providers="oauthProviders"/>
+      <v-divider />
+      <girder-oauth :providers="oauthProviders" />
     </template>
   </div>
 </template>
@@ -68,9 +75,7 @@ import GirderOauth from './OAuth.vue';
 const OTP_MAGIC_SUBSTRING = 'authentication must include a one-time password';
 
 // Validation rules
-const nonEmptyRules = [
-  v => !!v || 'Item is required',
-];
+const nonEmptyRules = [v => !!v || 'Item is required'];
 const otpRules = [
   (v) => {
     const phrase = '6 digit number';

--- a/src/components/Authentication/OAuth.vue
+++ b/src/components/Authentication/OAuth.vue
@@ -7,7 +7,8 @@
       :dark="iconMap[provider.id].dark"
       :color="iconMap[provider.id].color"
       :href="provider.url"
-      class="ml-0 mr-3">
+      class="ml-0 mr-3"
+    >
       <v-icon left="left">{{ $vuetify.icons.values[iconMap[provider.id].icon] }}</v-icon>
       {{ provider.name }}
     </v-btn>

--- a/src/components/Authentication/Register.vue
+++ b/src/components/Authentication/Register.vue
@@ -7,7 +7,8 @@
       class="mt-0"
       dismissible="dismissible"
       transition="scale-transition"
-      type="error">{{ err }}</v-alert>
+      type="error"
+    >{{ err }}</v-alert>
     <v-alert
       v-for="info in alerts.infos"
       :key="info"
@@ -15,53 +16,63 @@
       class="mt-0"
       dismissible="dismissible"
       transition="scale-transition"
-      type="info">{{ info }}</v-alert>
+      type="info"
+    >{{ info }}</v-alert>
     <v-container>
       <v-form
         ref="form"
-        @submit.prevent="register">
+        @submit.prevent="register"
+      >
         <v-text-field
           v-model="login"
           :rules="nonEmptyRules"
           label="Username"
           type="text"
-          autofocus="autofocus"/>
+          autofocus="autofocus"
+        />
         <v-text-field
           v-model="email"
           :rules="nonEmptyRules"
           label="Email"
-          type="email"/>
+          type="email"
+        />
         <v-text-field
           v-model="firstName"
           :rules="nonEmptyRules"
           label="First Name"
-          type="text"/>
+          type="text"
+        />
         <v-text-field
           v-model="lastName"
           :rules="nonEmptyRules"
           label="Last Name"
-          type="text"/>
+          type="text"
+        />
         <v-text-field
           v-model="password"
           :rules="nonEmptyRules"
           type="password"
-          label="Password"/>
+          label="Password"
+        />
         <v-text-field
           v-model="retypePassword"
           :rules="retypeMustMatchPasswordRules"
           type="password"
-          label="Retype password"/>
+          label="Retype password"
+        />
         <v-btn
           :loading="inProgress"
           class="ml-0"
           type="submit"
-          color="primary">Register</v-btn>
+          color="primary"
+        >Register</v-btn>
       </v-form>
     </v-container><template v-if="oauthProviders && oauthProviders.length">
-      <v-divider/>
+      <v-divider />
       <girder-oauth
         :providers="oauthProviders"
-        verb="register"/>
+        verb="register"
+      />
     </template>
   </div>
 </template>

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -107,19 +107,23 @@ export default {
       :disabled="location._id === girderRest.user._id"
       class="home-button mr-3"
       color="accent"
-      @click="$emit('crumbclick', girderRest.user)">$vuetify.icons.userHome</v-icon>
+      @click="$emit('crumbclick', girderRest.user)"
+    >$vuetify.icons.userHome</v-icon>
     <v-breadcrumbs
       :items="breadcrumb"
-      class="font-weight-bold pa-0">
+      class="font-weight-bold pa-0"
+    >
       <span
         slot="divider"
         :disabled="readonly"
-        class="subheading font-weight-bold">/</span>
+        class="subheading font-weight-bold"
+      >/</span>
       <template #item="{ item }">
         <v-breadcrumbs-item
           :disabled="(readonly || breadcrumb.indexOf(item) == breadcrumb.length-1)"
           tag="a"
-          @click="$emit('crumbclick', item)">
+          @click="$emit('crumbclick', item)"
+        >
           <template v-if="['folder', 'user', 'collection'].indexOf(item.type) !== -1">
             <span class="accent--text">{{ item.name }}</span>
           </template>

--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -324,35 +324,43 @@ export default {
     @drag="$emit('drag', $event)"
     @dragstart="$emit('dragstart', $event)"
     @dragend="$emit('dragend', $event)"
-    @drop="$emit('drop', $event)"><template #header="{ props, on }">
+    @drop="$emit('drop', $event)"
+  >
+    <template #header="{ props, on }">
       <thead>
         <tr
           :class="$vuetify.theme.dark?'darken-2':'lighten-5'"
-          class="secondary">
+          class="secondary"
+        >
           <th
             v-if="internalSelectable"
             class="pl-3 pr-0"
-            width="1%">
+            width="1%"
+          >
             <v-checkbox
               :input-value="props.everyItem"
               :indeterminate="internalValue.length > 0 && !props.everyItem"
               class="pr-2"
               color="accent"
               hide-details="hide-details"
-              @click.native="on['toggle-select-all'](!props.everyItem)"/>
+              @click.native="on['toggle-select-all'](!props.everyItem)"
+            />
           </th>
           <th
             class="pl-3"
             colspan="10"
-            width="99%">
+            width="99%"
+          >
             <v-row class="ma-1">
               <slot
                 v-bind="{ location, changeLocation, rootLocationDisabled }"
-                name="breadcrumb"/>
-              <v-spacer/>
+                name="breadcrumb"
+              />
+              <v-spacer />
               <slot
                 v-bind="{ location, changeLocation, rootLocationDisabled }"
-                name="headerwidget"/>
+                name="headerwidget"
+              />
             </v-row>
           </th>
         </tr>
@@ -360,6 +368,8 @@ export default {
     </template><template #row-widget="props">
       <slot
         v-bind="props"
-        name="row-widget"/>
-  </template></girder-data-table>
+        name="row-widget"
+      />
+    </template>
+  </girder-data-table>
 </template>

--- a/src/components/DataDetails.vue
+++ b/src/components/DataDetails.vue
@@ -4,18 +4,22 @@
       flat="flat"
       dark="dark"
       dense="dense"
-      color="primary">
+      color="primary"
+    >
       <v-toolbar-title class="subtitle-1">
         <v-icon class="pr-2 mdi-18px">{{ icon }}</v-icon>{{ title }}
       </v-toolbar-title>
-      <v-spacer/>
+      <v-spacer />
       <v-dialog
         v-if="datum"
         v-model="showUpsert"
-        max-width="800px"><template v-slot:activator="{ on }">
+        max-width="800px"
+      >
+        <template v-slot:activator="{ on }">
           <v-btn
             icon="icon"
-            v-on="on">
+            v-on="on"
+          >
             <v-icon class="mdi-18px">{{ $vuetify.icons.edit }}</v-icon>
           </v-btn>
         </template>
@@ -23,46 +27,57 @@
           :edit="true"
           :key="datum._id"
           :location="datum"
-          @dismiss="showUpsert = false"/>
+          @dismiss="showUpsert = false"
+        />
       </v-dialog>
     </v-toolbar>
     <girder-markdown
       v-if="details && details.description"
       :text="details.description"
-      class="mx-3 mt-2"/>
+      class="mx-3 mt-2"
+    />
     <girder-detail-list
       :rows="info"
-      title="Info"/>
+      title="Info"
+    />
     <girder-detail-list
       v-if="meta.length"
       :rows="meta"
-      title="Meta"><template #row="props">
+      title="Meta"
+    >
+      <template #row="props">
         <v-row justify="space-between">
           <v-col class="shrink py-1 body-2 font-weight-bold">{{ props.datum.key }}</v-col>
           <v-col class="py-1 body-2 d-flex justify-end">{{ props.datum.value }}</v-col>
         </v-row>
-    </template></girder-detail-list>
+      </template>
+    </girder-detail-list>
     <girder-detail-list
       v-if="files.length"
       :title="`Files (${files.length})`"
-      :rows="files"/>
+      :rows="files"
+    />
     <girder-detail-list
       v-if="actions.length"
       :clickable="true"
       :rows="actions"
       title="Actions"
-      @click="handleAction"><template #row="props">
+      @click="handleAction"
+    >
+      <template #row="props">
         <v-list-item-icon class="mr-1">
           <v-icon
             :color="props.datum.color"
-            class="pr-2">
+            class="pr-2"
+          >
             {{ props.datum.icon || $vuetify.icons.values[props.datum.iconKey] }}
           </v-icon>
         </v-list-item-icon>
         <v-list-item-content :class="`${props.datum.color}--text`">
           {{ props.datum.name }}
         </v-list-item-content>
-    </template></girder-detail-list>
+      </template>
+    </girder-detail-list>
   </v-card>
 </template>
 

--- a/src/components/Job/FilterForm.vue
+++ b/src/components/Job/FilterForm.vue
@@ -52,14 +52,16 @@ export default {
   <v-card
     class="job-filter"
     dark="dark"
-    color="primary">
+    color="primary"
+  >
     <v-card-title>
       <v-container>
         <h4>Jobs</h4>
         <v-row justify="center">
           <v-col
             sm="5"
-            md="4">
+            md="4"
+          >
             <v-select
               :items="jobTypeList"
               :value="jobType"
@@ -68,11 +70,13 @@ export default {
               clearable="clearable"
               color="white"
               dense="dense"
-              @input="$emit('update:jobType', $event ? $event : null)"/>
+              @input="$emit('update:jobType', $event ? $event : null)"
+            />
           </v-col>
           <v-col
             sm="5"
-            md="4">
+            md="4"
+          >
             <v-select
               :items="statusItemList"
               :value="status"
@@ -81,7 +85,8 @@ export default {
               clearable="clearable"
               color="white"
               dense="dense"
-              @input="$emit('update:status', $event ? $event : null)"/>
+              @input="$emit('update:status', $event ? $event : null)"
+            />
           </v-col>
         </v-row>
       </v-container>

--- a/src/components/Job/JobList.vue
+++ b/src/components/Job/JobList.vue
@@ -111,25 +111,30 @@ export default {
 <template>
   <v-card
     class="girder-job-list"
-    color="primary">
+    color="primary"
+  >
     <filter-form
       :from-date.sync="jobFilter.fromDate"
       :to-date.sync="jobFilter.toDate"
       :status.sync="jobFilter.status"
       :job-type.sync="jobFilter.jobType"
       :status-list="typeAndStatusList.statuses"
-      :job-type-list="typeAndStatusList.types"/>
+      :job-type-list="typeAndStatusList.types"
+    />
     <job-table
       :jobs="jobs"
       :options.sync="options"
       :more-pages="morePages"
-      @job-click="(e, job) => $emit('job-click', e, job)">
+      @job-click="(e, job) => $emit('job-click', e, job)"
+    >
       <template
         v-if="$scopedSlots.jobwidget"
-        #jobwidget="props">
+        #jobwidget="props"
+      >
         <slot
           v-bind="props"
-          name="jobwidget"/>
+          name="jobwidget"
+        />
       </template>
     </job-table>
   </v-card>

--- a/src/components/Job/JobTable.vue
+++ b/src/components/Job/JobTable.vue
@@ -70,7 +70,9 @@ export default {
     :server-items-length="serverItemsLength"
     :options="options"
     item-key="_id"
-    @update:options="$emit('update:options', $event)"><template #item="props">
+    @update:options="$emit('update:options', $event)"
+  >
+    <template #item="props">
       <tr @click="$emit('job-click', $event, props.item)">
         <td class="one-line">{{ props.item.title }}</td>
         <td class="one-line">{{ props.item.type }}</td>
@@ -78,18 +80,22 @@ export default {
         <td
           :title="props.item.statusText"
           class="one-line"
-          nowrap="nowrap">
-          <job-progress :formatted-job="props.item"/>
+          nowrap="nowrap"
+        >
+          <job-progress :formatted-job="props.item" />
         </td>
         <td class="one-line pa-0">
           <slot
             v-bind="props"
-            name="jobwidget"/>
+            name="jobwidget"
+          />
         </td>
       </tr>
-    </template><template #footer.page-text="">
+    </template>
+    <template #footer.page-text="">
       <div class="v-datatable__actions__options">{{ pageRange.first }}-{{ pageRange.last }}</div>
-  </template></v-data-table>
+    </template>
+  </v-data-table>
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -21,7 +21,8 @@ export default {
 <template>
   <div
     class="g-md-viewer"
-    v-html="markdown" />
+    v-html="markdown"
+  />
 </template>
 
 <style lang="scss">

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -42,7 +42,8 @@ export default {
   <div class="girder-markdown-editor">
     <v-tabs
       v-model="activeTab"
-      class="md-tab">
+      class="md-tab"
+    >
       <v-tab key="edit">Edit</v-tab>
       <v-tab-item>
         <v-textarea
@@ -51,28 +52,32 @@ export default {
           :placeholder="placeholder"
           hide-details="hide-details"
           filled="filled"
-          single-line="single-line"/>
+          single-line="single-line"
+        />
       </v-tab-item>
       <v-tab key="preview">Preview</v-tab>
       <v-tab-item class="md-preview pa-2 grey lighten-3">
-        <girder-markdown :text="text_"/>
+        <girder-markdown :text="text_" />
       </v-tab-item>
     </v-tabs>
     <v-toolbar
       dark="dark"
-      color="secondary darken-2">
+      color="secondary darken-2"
+    >
       <span class="hidden-xs-only">
         Supports <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet">Markdown</a>
       </span>
-      <v-spacer/>
+      <v-spacer />
       <v-toolbar-items>
         <v-btn
           :class="{ active: activeTab === 0 }"
           text="text"
-          @click="activeTab = 0">
+          @click="activeTab = 0"
+        >
           <v-row
             class="flex-column align-center justify-content"
-            no-gutters="no-gutters">
+            no-gutters="no-gutters"
+          >
             <v-icon class="mdi-24px">$vuetify.icons.edit</v-icon>
             <span class="caption text-capitalize">Write</span>
           </v-row>
@@ -80,10 +85,12 @@ export default {
         <v-btn
           :class="{ active: activeTab === 1 }"
           text="text"
-          @click="activeTab = 1">
+          @click="activeTab = 1"
+        >
           <v-row
             class="flex-column align-center justify-content"
-            no-gutters="no-gutters">
+            no-gutters="no-gutters"
+          >
             <v-icon class="mdi-24px">$vuetify.icons.preview</v-icon>
             <span class="caption text-capitalize">Preview</span>
           </v-row>

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -85,11 +85,15 @@ export default {
     hide-default-header="hide-default-header"
     item-key="_id"
     @input="$emit('input', $event)"
-    @update:options="$emit('update:options', $event)"><template #header="vDataTableHeaderProps">
+    @update:options="$emit('update:options', $event)"
+  >
+    <template #header="vDataTableHeaderProps">
       <slot
         v-bind="vDataTableHeaderProps"
-        name="header"/>
-    </template><template #item="props">
+        name="header"
+      />
+    </template>
+    <template #item="props">
       <tr
         :draggable="draggable"
         :active="props.isSelected"
@@ -100,42 +104,56 @@ export default {
         @drag="$emit('drag', { items: [props], event: $event })"
         @dragstart="$emit('dragstart', { items: [props], event: $event })"
         @dragend="$emit('dragend', { items: [props], event: $event })"
-        @drop="$emit('drop', { items: [props], event: $event })">
+        @drop="$emit('drop', { items: [props], event: $event })"
+      >
         <td
           v-if="selectable"
-          class="pl-3 pr-0">
+          class="pl-3 pr-0"
+        >
           <v-checkbox
             :input-value="props.isSelected"
             accent="accent"
             hide-details="hide-details"
-            @change="props.select"/>
+            @change="props.select"
+          />
         </td>
         <td
           class="pl-3"
           colspan="2"
-          @contextmenu="$emit('row-right-click', props.item, $event)"><span
+          @contextmenu="$emit('row-right-click', props.item, $event)"
+        >
+          <span
             :class="getItemClass(props.item)"
             class="text-container nobreak"
-            @click.stop="$emit('rowclick', props.item)">
+            @click.stop="$emit('rowclick', props.item)"
+          >
             <v-icon
               :color="props.isSelected ? 'accent' : ''"
-              class="pr-2">{{ $vuetify.icons.values[props.item.icon] }}</v-icon>
+              class="pr-2"
+            >{{ $vuetify.icons.values[props.item.icon] }}</v-icon>
             {{ props.item.name }}
             <slot
               v-bind="props"
-              name="row-widget"/>
-        </span></td>
+              name="row-widget"
+            />
+          </span>
+        </td>
         <td class="text-right nobreak">{{ props.item.humanSize }}</td>
       </tr>
-    </template><template #no-data="">
+    </template>
+    <template #no-data="">
       <div
         class="text-center"
-        width="100%">No Data Available</div>
-    </template><template #no-results="">
+        width="100%"
+      >No Data Available</div>
+    </template>
+    <template #no-results="">
       <div
         class="text-center"
-        width="100%">No Data Available</div>
-  </template></v-data-table>
+        width="100%"
+      >No Data Available</div>
+    </template>
+  </v-data-table>
 </template>
 
 

--- a/src/components/Presentation/DetailList.vue
+++ b/src/components/Presentation/DetailList.vue
@@ -1,16 +1,19 @@
 <template>
   <v-list
     v-if="rows.length"
-    dense="dense">
+    dense="dense"
+  >
     <v-subheader class="subtitle-1 font-weight-bold pl-4">{{ title }}</v-subheader>
     <template v-for="(val, i) in rows">
       <v-list-item
         :key="`${i}-li`"
         class="allow-select"
-        v-on="clickable ? {click: () => $emit('click', val)} : {}">
+        v-on="clickable ? {click: () => $emit('click', val)} : {}"
+      >
         <slot
           :datum="val"
-          name="row">
+          name="row"
+        >
           <v-list-item-content>
             <div class="body-2 no-overflow">{{ val }}</div>
           </v-list-item-content>
@@ -19,7 +22,8 @@
       <v-divider
         v-if="i < rows.length - 1"
         :key="`${i}-divider`"
-        class="mx-3"/>
+        class="mx-3"
+      />
     </template>
   </v-list>
 </template>

--- a/src/components/Presentation/Dropzone.vue
+++ b/src/components/Presentation/Dropzone.vue
@@ -4,7 +4,8 @@
     class="dropzone-wrapper"
     @dragenter="dropzoneClass = 'animate'"
     @dragleave="dropzoneClass = null"
-    @drop="dropzoneClass = null">
+    @drop="dropzoneClass = null"
+  >
     <v-row class="flex-column align-center justify-center fill-height dropzone-message">
       <v-icon size="50px">$vuetify.icons.fileUpload</v-icon>
       <div class="title mt-3">{{ message }}</div>
@@ -13,7 +14,8 @@
       :accept="accept"
       class="file-input"
       type="file"
-      @change="$emit('change', Array(...$event.target.files))" >
+      @change="$emit('change', Array(...$event.target.files))"
+    >
   </div>
 </template>
 

--- a/src/components/Presentation/FileUploadList.vue
+++ b/src/components/Presentation/FileUploadList.vue
@@ -1,19 +1,22 @@
 <template>
   <v-list
     v-show="value.length"
-    dense="dense">
+    dense="dense"
+  >
     <div
       v-for="(file, i) in shownFiles"
       :key="file.file.name"
       :class="`status-${file.status}`"
-      class="file-tile">
-      <v-divider v-if="i > 0"/>
+      class="file-tile"
+    >
+      <v-divider v-if="i > 0" />
       <v-list-item>
         <v-list-item-icon>
           <v-btn
             v-if="file.status === 'pending'"
             icon="icon"
-            @click="$emit('input', splice(i))">
+            @click="$emit('input', splice(i))"
+          >
             <v-icon>$vuetify.icons.close</v-icon>
           </v-btn>
           <v-progress-circular
@@ -21,15 +24,18 @@
             :rotate="-90"
             :value="progressPercent({...file.progress, total: file.progress.size })"
             :indeterminate="file.progress.indeterminate"
-            color="primary"/>
+            color="primary"
+          />
           <v-icon
             v-if="file.status === 'done'"
             color="success"
-            large="large">$vuetify.icons.complete</v-icon>
+            large="large"
+          >$vuetify.icons.complete</v-icon>
           <v-icon
             v-if="file.status === 'error'"
             color="error"
-            large="large">$vuetify.icons.error</v-icon>
+            large="large"
+          >$vuetify.icons.error</v-icon>
         </v-list-item-icon>
         <v-list-item-content>
           <v-list-item-title>{{ file.file.name }}</v-list-item-title>
@@ -40,10 +46,11 @@
         </v-list-item-content>
         <slot
           v-bind="{ file }"
-          name="item"/>
+          name="item"
+        />
       </v-list-item>
     </div><template v-if="hiddenCount">
-      <v-divider/>
+      <v-divider />
       <v-list-item>
         <v-list-item-content>
           <div class="grey--text subtitle-1">+ {{ hiddenCount }} more...</div>
@@ -98,9 +105,7 @@ export default {
 
 <style lang="scss" scoped>
 .file-tile {
-  transition:
-    width 0.8s ease-in-out 1s,
-    height 0.8s ease-in-out 1s,
+  transition: width 0.8s ease-in-out 1s, height 0.8s ease-in-out 1s,
     background-color 0.5s ease-in-out;
   width: 100%;
 

--- a/src/components/Presentation/FileUploadList.vue
+++ b/src/components/Presentation/FileUploadList.vue
@@ -105,7 +105,9 @@ export default {
 
 <style lang="scss" scoped>
 .file-tile {
-  transition: width 0.8s ease-in-out 1s, height 0.8s ease-in-out 1s,
+  transition:
+    width 0.8s ease-in-out 1s,
+    height 0.8s ease-in-out 1s,
     background-color 0.5s ease-in-out;
   width: 100%;
 

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -326,9 +326,11 @@ export default {
       0% {
         background-position: 0% 51%;
       }
+
       50% {
         background-position: 100% 50%;
       }
+
       100% {
         background-position: 0% 51%;
       }

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -158,18 +158,22 @@ export default {
 <template>
   <v-row
     class="align-center girder-searchbar"
-    no-gutters="no-gutters">
+    no-gutters="no-gutters"
+  >
     <v-icon
       v-if="!hideSearchIcon"
       class="mr-3 mdi-24px"
-      color="white">$vuetify.icons.search</v-icon>
+      color="white"
+    >$vuetify.icons.search</v-icon>
     <v-menu
       :open-on-click="false"
       :value="searchText"
       :nudge-bottom="6"
       offset-y="offset-y"
       content-class="girder-searchbar-menu"
-      transition="slide-y-transition"><template #activator="{ on }">
+      transition="slide-y-transition"
+    >
+      <template #activator="{ on }">
         <v-text-field
           v-model="searchText"
           :placeholder="placeholder"
@@ -177,17 +181,20 @@ export default {
           solo="solo"
           hide-details="hide-details"
           clearable="clearable"
-          v-on="on"/>
+          v-on="on"
+        />
       </template>
       <v-list dense="dense">
         <v-list-item
           v-for="result in quickResults"
           v-show="!loading"
           :key="result._id"
-          @click="selectResult(result)">
+          @click="selectResult(result)"
+        >
           <slot
             v-bind="result"
-            name="searchresult">
+            name="searchresult"
+          >
             <v-list-item-action class="mr-2">
               <v-icon>{{ $vuetify.icons.values[result._modelType] }}</v-icon>
             </v-list-item-action>
@@ -199,7 +206,8 @@ export default {
         <v-list-item v-show="searchText && quickResults.length === 0 && !loading">
           <slot
             v-bind="{ searchText }"
-            name="noresult">
+            name="noresult"
+          >
             <v-list-item-action>
               <v-icon>$vuetify.icons.alert</v-icon>
             </v-list-item-action>
@@ -213,7 +221,8 @@ export default {
         </v-list-item>
         <v-list-item
           v-show="!loading && showMore && searchResults.length > maxQuickResults"
-          @click="$emit('moreresults', searchParams)">
+          @click="$emit('moreresults', searchParams)"
+        >
           <v-list-item-action>
             <v-icon>$vuetify.icons.more</v-icon>
           </v-list-item-action>
@@ -224,17 +233,20 @@ export default {
         <v-list-item
           v-for="i in Math.round(maxQuickResults / 2)"
           v-show="loading"
-          :key="`skeleton-${i}`">
+          :key="`skeleton-${i}`"
+        >
           <v-list-item-action>
             <v-icon class="grey--text text--lighten-1">$vuetify.icons.circle</v-icon>
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title
               :style="{ maxWidth: (70 + (4 * (i % 3))) + '%', height: '12px' }"
-              class="skeleton skeleton--text mb-2"/>
+              class="skeleton skeleton--text mb-2"
+            />
             <v-list-item-subtitle
               :style="{ maxWidth: (50 - (4 * (i % 2))) + '%', height: '6px' }"
-              class="skeleton skeleton--text"/>
+              class="skeleton skeleton--text"
+            />
           </v-list-item-content>
         </v-list-item>
       </v-list>
@@ -245,10 +257,13 @@ export default {
       :close-on-content-click="false"
       offset-y="offset-y"
       left="left"
-      content-class="girder-search-arrow-menu"><template #activator="{ on }">
+      content-class="girder-search-arrow-menu"
+    >
+      <template #activator="{ on }">
         <v-btn
           icon="icon"
-          v-on="on">
+          v-on="on"
+        >
           <v-icon class="mdi-24px">$vuetify.icons.settings</v-icon>
         </v-btn>
       </template>
@@ -256,19 +271,22 @@ export default {
         <v-card-actions>
           <v-col
             class="pa-0 flex-column"
-            no-gutters="no-gutters">
+            no-gutters="no-gutters"
+          >
             <v-radio-group
               v-model="internalSearchMode"
               class="my-2"
-              hide-details="hide-details">
+              hide-details="hide-details"
+            >
               <v-radio
                 v-for="mode in searchModeOptions"
                 :key="mode.value"
                 :label="mode.name"
                 :value="mode.value"
-                class="mb-1"/>
+                class="mb-1"
+              />
             </v-radio-group>
-            <v-divider/>
+            <v-divider />
             <v-checkbox
               v-for="searchType in searchTypeOptions"
               :key="searchType.value"
@@ -276,7 +294,8 @@ export default {
               :label="searchType.name"
               :value="searchType.value"
               class="mt-1"
-              hide-details="hide-details"/>
+              hide-details="hide-details"
+            />
           </v-col>
         </v-card-actions>
       </v-card>
@@ -304,9 +323,15 @@ export default {
     animation: SkeletonShimmer 2s ease infinite;
 
     @keyframes SkeletonShimmer {
-      0% { background-position: 0% 51%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 51%; }
+      0% {
+        background-position: 0% 51%;
+      }
+      50% {
+        background-position: 100% 50%;
+      }
+      100% {
+        background-position: 0% 51%;
+      }
     }
   }
 }

--- a/src/components/Snippet/FileManager.vue
+++ b/src/components/Snippet/FileManager.vue
@@ -208,27 +208,33 @@ export default {
       @drag="$emit('drag', $event)"
       @dragstart="$emit('dragstart', $event)"
       @dragend="$emit('dragend', $event)"
-      @drop="$emit('drop', $event)">
+      @drop="$emit('drop', $event)"
+    >
       <template #breadcrumb="props">
         <girder-breadcrumb
           :location="props.location"
           :root-location-disabled="props.rootLocationDisabled"
-          @crumbclick="props.changeLocation($event)"/>
+          @crumbclick="props.changeLocation($event)"
+        />
       </template><template #headerwidget>
-        <slot name="headerwidget"/>
+        <slot name="headerwidget" />
         <v-dialog
           v-if="shouldShowUpload"
           v-model="uploaderDialog"
-          max-width="800px"><template #activator="{ on }">
+          max-width="800px"
+        >
+          <template #activator="{ on }">
             <v-btn
               class="ma-0"
               text="text"
               small="small"
-              v-on="on">
+              v-on="on"
+            >
               <v-icon
                 class="mdi-24px mr-1"
                 left="left"
-                color="accent">$vuetify.icons.fileNew</v-icon>
+                color="accent"
+              >$vuetify.icons.fileNew</v-icon>
               <span class="hidden-xs-only">Upload</span>
             </v-btn>
           </template>
@@ -238,21 +244,26 @@ export default {
             :post-upload="postUploadInternal"
             :multiple="uploadMultiple"
             :max-show="uploadMaxShow"
-            :accept="uploadAccept"/>
+            :accept="uploadAccept"
+          />
         </v-dialog>
         <v-dialog
           v-if="newFolderEnabled && !isRootLocation(internalLocation) && girderRest.user"
           v-model="newFolderDialog"
-          max-width="800px"><template #activator="{ on }">
+          max-width="800px"
+        >
+          <template #activator="{ on }">
             <v-btn
               class="ma-0"
               text="text"
               small="small"
-              v-on="on">
+              v-on="on"
+            >
               <v-icon
                 class="mdi-24px mr-1"
                 left="left"
-                color="accent">$vuetify.icons.folderNew</v-icon>
+                color="accent"
+              >$vuetify.icons.folderNew</v-icon>
               <span class="hidden-xs-only">New Folder</span>
             </v-btn>
           </template>
@@ -261,24 +272,29 @@ export default {
             :pre-upsert="preUpsert"
             :post-upsert="postUpsertInternal"
             :key="internalLocation._id"
-            @dismiss="newFolderDialog = false"/>
+            @dismiss="newFolderDialog = false"
+          />
         </v-dialog>
       </template><template #row-widget="props">
         <slot
           v-bind="props"
-          name="row-widget"/>
-    </template></girder-data-browser>
+          name="row-widget"
+        />
+      </template>
+    </girder-data-browser>
     <v-menu
       v-model="collectionAndFolderMenu.show"
       :position-x="collectionAndFolderMenu.x"
       :position-y="collectionAndFolderMenu.y"
       absolute="absolute"
       offset-y="offset-y"
-      dark="dark">
+      dark="dark"
+    >
       <v-list dense="dense">
         <v-list-item
           :disabled="!hasAccessPermission"
-          @click="showAccessControlDialog=true">
+          @click="showAccessControlDialog=true"
+        >
           <v-list-item-title>Access control</v-list-item-title>
         </v-list-item>
       </v-list>
@@ -288,13 +304,15 @@ export default {
       max-width="700px"
       persistent="persistent"
       eager="eager"
-      scrollable="scrollable">
+      scrollable="scrollable"
+    >
       <girder-access-control
         v-if="actOnItem"
         :model="actOnItem"
         :has-permission.sync="hasAccessPermission"
         @close="showAccessControlDialog=false"
-        @model-access-changed="$refs.girderBrowser.refresh()"/>
+        @model-access-changed="$refs.girderBrowser.refresh()"
+      />
     </v-dialog>
   </v-card>
 </template>

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -1,16 +1,19 @@
 <template>
   <v-card
     class="fill-height"
-    flat="flat">
+    flat="flat"
+  >
     <v-row
       class="flex-column fill-height"
-      no-gutters="no-gutters">
+      no-gutters="no-gutters"
+    >
       <slot name="header">
         <v-card-title primary-title="primary-title">
           <div>
             <div
               v-if="!hideHeadline"
-              class="headline">Upload to <span class="font-weight-bold">{{ dest.name }}</span>
+              class="headline"
+            >Upload to <span class="font-weight-bold">{{ dest.name }}</span>
             </div>
             <div class="grey--text title">{{ statusMessage }}</div>
           </div>
@@ -20,16 +23,19 @@
         v-if="uploading"
         :value="totalProgressPercent"
         :indeterminate="indeterminate"
-        height="20"/>
+        height="20"
+      />
       <v-card-actions v-show="files.length && !errorMessage && !uploading">
         <v-btn
           text="text"
-          @click="reset">Clear all</v-btn>
+          @click="reset"
+        >Clear all</v-btn>
         <v-btn
           v-if="!hideStartButton"
           text="text"
           color="primary"
-          @click="startUpload">{{ startButtonText }}</v-btn>
+          @click="startUpload"
+        >{{ startButtonText }}</v-btn>
       </v-card-actions>
       <v-col>
         <slot name="dropzone">
@@ -38,7 +44,8 @@
             :message="dropzoneMessage"
             :multiple="multiple"
             :accept="accept"
-            @change="inputFilesChanged"/>
+            @change="inputFilesChanged"
+          />
         </slot>
       </v-col>
       <div v-if="errorMessage">
@@ -46,29 +53,34 @@
           :value="true"
           dark="dark"
           tile="tile"
-          type="error">{{ errorMessage }}
+          type="error"
+        >{{ errorMessage }}
           <v-btn
             v-if="!uploading"
             class="ml-3"
             dark="dark"
             small="small"
             outlined="outlined"
-            @click="startUpload">Resume upload</v-btn>
+            @click="startUpload"
+          >Resume upload</v-btn>
           <v-btn
             v-if="!uploading"
             class="ml-3"
             dark="dark"
             small="small"
             outlined="outlined"
-            @click="reset">Abort</v-btn>
+            @click="reset"
+          >Abort</v-btn>
         </v-alert>
       </div>
       <slot
         v-bind="{ files, setFiles, maxShow }"
-        name="files">
+        name="files"
+      >
         <file-upload-list
           v-bind="{ value: files, maxShow }"
-          @input="setFiles"/>
+          @input="setFiles"
+        />
       </slot>
     </v-row>
   </v-card>

--- a/src/components/UpsertFolder.vue
+++ b/src/components/UpsertFolder.vue
@@ -111,12 +111,14 @@ export default {
     <v-card flat="flat">
       <v-row
         class="pa-2 flex-column"
-        no-gutters="no-gutters">
+        no-gutters="no-gutters"
+      >
         <slot name="header">
           <v-card-title
             class="pb-0"
-            primary-title="primary-title">
-            <h5 class="display-1"/>{{ edit ? 'Edit Folder' : 'Create New Folder' }}
+            primary-title="primary-title"
+          >
+            <h5 class="display-1" />{{ edit ? 'Edit Folder' : 'Create New Folder' }}
           </v-card-title>
         </slot>
         <v-card-text>
@@ -124,30 +126,36 @@ export default {
             ref="folderName"
             v-model="name"
             autofocus="autofocus"
-            label="Folder Name"/>
+            label="Folder Name"
+          />
           <girder-breadcrumb
             v-bind="{ location, append }"
             class="mb-3"
-            readonly="readonly"/>
+            readonly="readonly"
+          />
           <girder-markdown-editor
             v-model="description"
-            label="Description (Optional)"/>
+            label="Description (Optional)"
+          />
           <v-alert
             :value="!!error"
             type="error"
             dismissible="dismissible"
-            transition="scale-transition">{{ error }}</v-alert>
+            transition="scale-transition"
+          >{{ error }}</v-alert>
         </v-card-text>
         <v-card-actions>
-          <v-spacer/>
+          <v-spacer />
           <v-btn
             text="text"
-            @click="$emit('dismiss')">Cancel</v-btn>
+            @click="$emit('dismiss')"
+          >Cancel</v-btn>
           <v-btn
             :disabled="!name"
             depressed="depressed"
             color="primary"
-            type="submit">{{ edit ? 'Save Changes' : 'Create Folder' }}</v-btn>
+            type="submit"
+          >{{ edit ? 'Save Changes' : 'Create Folder' }}</v-btn>
         </v-card-actions>
       </v-row>
     </v-card>


### PR DESCRIPTION
Turns out autoformatting is hard.

* https://github.com/vuejs/vetur/issues/695 -- Vetur doesn't support a single autoformatter that is capable of running `eslint --fix` with our configuration.  You can try to find a prettier config that happens to overlap, but I don't believe it's possible.
* As a result, I've turned js autoformatting with vetur off for VS Code.  Eslint is much smarter than any prettier config.
* However, I did turn on lint-on-save features, which do read `eslintConfig` from package.json.  It's basically like running `yarn lint` every time you save

HTML formatting was another animal. Eslint isn't that opinionated about html formatting, and I think we should be more rigorous when possible.

For example:

```html
<v-tab-item key="login-box">
  <girder-login
            :oauth-providers="oauthProviders"
            v-bind="{ forceOtp, forgotPasswordUrl, forgotPasswordRoute, hideForgotPassword }"
            @forgotpassword="$emit('forgotpassword')" /> </v-tab-item>
```

eslint doesn't mind if you do stuff like this, but I'd prefer to be more strict:

```
      <v-tab-item key="login-box">
        <girder-login
          :oauth-providers="oauthProviders"
          v-bind="{ forceOtp, forgotPasswordUrl, forgotPasswordRoute, hideForgotPassword }"
          @forgotpassword="$emit('forgotpassword')"
        />
      </v-tab-item>
```

autoformatting with `js-beautify` will produce this, but more work is needed to figure out how to get it to run in CI.  I think this PR provides reasonable middle ground for VS Code users: hitting `ctrl+shift+i` will perform autoformatting.

I'd love to bring back `yarn lint:html` but I've spent too long on this this morning so far.  Settings for https://github.com/beautify-web/js-beautify can probably be found so that we can run `js-beautify` from a package.json command.

