### PR TITLE
Expose job table as slot differently

### DIFF
--- a/src/components/Job/JobList.vue
+++ b/src/components/Job/JobList.vue
@@ -121,21 +121,16 @@ export default {
       :status-list="typeAndStatusList.statuses"
       :job-type-list="typeAndStatusList.types"
     />
-    <job-table
-      :jobs="jobs"
-      :options.sync="options"
-      :more-pages="morePages"
-      @job-click="(e, job) => $emit('job-click', e, job)"
+    <slot
+      v-bind="{ jobs, options, morePages }"
+      name="jobTable"
     >
-      <template
-        v-if="$scopedSlots.jobwidget"
-        #jobwidget="props"
-      >
-        <slot
-          v-bind="props"
-          name="jobwidget"
-        />
-      </template>
-    </job-table>
+      <job-table
+        :jobs="jobs"
+        :options.sync="options"
+        :more-pages="morePages"
+        @job-click="(e, job) => $emit('job-click', e, job)"
+      />
+    </slot>
   </v-card>
 </template>

--- a/src/components/Job/JobTable.vue
+++ b/src/components/Job/JobTable.vue
@@ -2,6 +2,20 @@
 import { jobFormatter } from '../../utils/mixins';
 import JobProgress from './JobProgress.vue';
 
+export const defaultHeaders = [{
+  text: 'Job Title',
+  value: 'title',
+}, {
+  text: 'Type',
+  value: 'type',
+}, {
+  text: 'Last Updated',
+  value: 'updated',
+}, {
+  text: 'Status',
+  value: 'status',
+}];
+
 export default {
   components: { JobProgress },
   mixins: [jobFormatter],
@@ -18,34 +32,14 @@ export default {
       type: Boolean,
       default: true,
     },
-  },
-  data() {
-    return {
-      headers: [{
-        text: 'Job Title',
-        value: 'title',
-      }, {
-        text: 'Type',
-        value: 'type',
-      }, {
-        text: 'Last Updated',
-        value: 'updated',
-      }, {
-        text: 'Status',
-        value: 'status',
-      }],
-    };
+    headers: {
+      type: Array,
+      default: () => defaultHeaders,
+    },
   },
   computed: {
     items() {
       return this.jobs.map(this.formatJob);
-    },
-    headers_() {
-      const widgetHeader = {
-        sortable: false,
-        align: 'end',
-      };
-      return this.headers.concat(this.$scopedSlots.jobwidget ? widgetHeader : []);
     },
     serverItemsLength() {
       let { last } = this.pageRange;
@@ -65,7 +59,7 @@ export default {
 
 <template>
   <v-data-table
-    :headers="headers_"
+    :headers="headers"
     :items="items"
     :server-items-length="serverItemsLength"
     :options="options"
@@ -73,30 +67,29 @@ export default {
     @update:options="$emit('update:options', $event)"
   >
     <template #item="props">
-      <tr @click="$emit('job-click', $event, props.item)">
-        <td class="one-line">
-          {{ props.item.title }}
-        </td>
-        <td class="one-line">
-          {{ props.item.type }}
-        </td>
-        <td class="one-line">
-          {{ props.item.updateString }}
-        </td>
-        <td
-          :title="props.item.statusText"
-          class="one-line"
-          nowrap="nowrap"
-        >
-          <job-progress :formatted-job="props.item" />
-        </td>
-        <td class="one-line pa-0">
-          <slot
-            v-bind="props"
-            name="jobwidget"
-          />
-        </td>
-      </tr>
+      <slot
+        v-bind="props"
+        name="jobrow"
+      >
+        <tr @click="$emit('job-click', $event, props.item)">
+          <td class="one-line">
+            {{ props.item.title }}
+          </td>
+          <td class="one-line">
+            {{ props.item.type }}
+          </td>
+          <td class="one-line">
+            {{ props.item.updateString }}
+          </td>
+          <td
+            :title="props.item.statusText"
+            class="one-line"
+            nowrap="nowrap"
+          >
+            <job-progress :formatted-job="props.item" />
+          </td>
+        </tr>
+      </slot>
     </template>
     <template #footer.page-text="">
       <div class="v-datatable__actions__options">


### PR DESCRIPTION
* removes jobsWidget slot, since it was underpowered
* exposes jobs table as slot
* exposes jobs row as slot.

In order to use the jobs row slot, you have to also use the jobs table slot.  It may be reasonable to say that the jobs table doesn't provide enough value on its own to expose this, so if a consumer wants to extend the jobs table, they're on their own to just implement the whole thing.