### PR TITLE
Make download actions links

### DIFF
--- a/src/components/DataDetails.vue
+++ b/src/components/DataDetails.vue
@@ -322,7 +322,7 @@ export default {
     },
     urlForAction(action) {
       return action.url(this.girderRest.apiRoot, this.value);
-    }
+    },
   },
 };
 </script>

--- a/src/components/DataDetails.vue
+++ b/src/components/DataDetails.vue
@@ -151,6 +151,7 @@ export const DefaultInfoKeys = [
  *  name: String,
  *  icon: String,
  *  color: String,
+ *  url?: Function,
  *  handler: Function,
  * }>}
  */


### PR DESCRIPTION
In order to make the `View Item`, `Download`, and `Download (zip)`
actions more useable, embed their text into a link rather than
exclusively rely on using click events. This allows users to open them
in a new tab or copy the link address.

Functionally, the only change is that the action text is now rendered as a link, and behaves like a link when right-clicked. The rest of the action button reacts and behaves the same. I think it's useful for the text to be rendered as a link to indicate that the normal link actions can be done on it.

Screenshots taken from the demo app:
![Screenshot from 2020-04-27 12-31-50](https://user-images.githubusercontent.com/577946/80396807-333dc180-8883-11ea-8d1b-3e16350980ef.png)
![Screenshot from 2020-04-27 12-32-03](https://user-images.githubusercontent.com/577946/80396808-33d65800-8883-11ea-8ac5-4836fde3067f.png)


Closes #225
Also closes https://github.com/dandi/dandiarchive/issues/82