### PR TITLE
225 suggestion

### DIFF
--- a/src/components/Presentation/DetailList.vue
+++ b/src/components/Presentation/DetailList.vue
@@ -9,6 +9,8 @@
     <template v-for="(val, i) in rows">
       <v-list-item
         :key="`${i}-li`"
+        :href="val.url"
+        :target="val.target"
         class="allow-select"
         v-on="clickable ? {click: () => $emit('click', val)} : {}"
       >


### PR DESCRIPTION
@dchiquit I don't typically like to butt in on other people's features like this, but I needed to mess around with code to see if my idea would even work.

Here's a suggestion that I think simplifies things a bit.  The one part of your PR that I was opposed to was the use of `this` inside the `ActionKeys` handler function, because it isn't clear how the function context gets set and I found it confusing.  I know I did it that way initially, and that wasn't great.

Now, the `actions` computed prop adds a computed `url` to the action iff a `urlfunc` exists, and if that is found, the `v-list-item` `href` (and optionally, `target`) are used.

Let me know what you think.  We don't have to actually merge this PR, just thought it'd be helpful to see.