### PR TITLE
Make download actions links

### DIFF
--- a/src/components/Presentation/DetailList.vue
+++ b/src/components/Presentation/DetailList.vue
@@ -10,7 +10,8 @@
       <v-list-item
         :key="`${i}-li`"
         class="allow-select"
-        :href="(href) ? href(val) : undefined"
+        :href="val.href"
+        :target="val.target"
         v-on="clickable ? {click: () => $emit('click', val)} : {}"
       >
         <slot
@@ -47,10 +48,6 @@ export default {
     clickable: {
       type: Boolean,
       default: false,
-    },
-    href: {
-      type: Function,
-      default: undefined,
     },
   },
 };

--- a/src/components/Presentation/DetailList.vue
+++ b/src/components/Presentation/DetailList.vue
@@ -10,6 +10,7 @@
       <v-list-item
         :key="`${i}-li`"
         class="allow-select"
+        :href="(href) ? href(val) : undefined"
         v-on="clickable ? {click: () => $emit('click', val)} : {}"
       >
         <slot
@@ -46,6 +47,10 @@ export default {
     clickable: {
       type: Boolean,
       default: false,
+    },
+    href: {
+      type: Function,
+      default: undefined,
     },
   },
 };


### PR DESCRIPTION
In order to make the `View Item`, `Download`, and `Download (zip)`
actions more useable, embed their text into a link rather than
exclusively rely on using click events. This allows users to open them
in a new tab or copy the link address.

![Screenshot from 2020-04-27 16-23-25](https://user-images.githubusercontent.com/577946/80421074-e1f4f880-88a9-11ea-9115-349196a73d8f.png)
![Screenshot from 2020-04-27 16-23-49](https://user-images.githubusercontent.com/577946/80421075-e28d8f00-88a9-11ea-9afd-5e057461c27c.png)


Closes #225
Also closes dandi/dandiarchive#82
Deprecates #252 