### PR TITLE
Allow preUpload to update dest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -190,7 +190,7 @@ const fileUploader = {
       this.uploading = true;
       this.indeterminate = true;
       this.errorMessage = null;
-      await preUpload();
+      const hookResult = await preUpload();
       this.indeterminate = false;
       const promiseList = this.files.map((file) => {
         let promiseChain = Promise.resolve();
@@ -209,7 +209,7 @@ const fileUploader = {
           // eslint-disable-next-line new-cap
           file.upload = new uploadCls(file.file, {
             $rest: this.girderRest,
-            parent: dest,
+            parent: (hookResult && hookResult.dest) ? hookResult.dest : dest,
             progress,
             params: file.uploadClsParams,
           });


### PR DESCRIPTION
When uploading files `dest` gets set before the `preUpload` function can make any changes to `dest`. This change will allow `preUpload` to potentially update `dest`, while keeping `dest` the same if `preUpload` does not make any updates to it.