### PR TITLE
set result.file to file

### DIFF
--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -223,6 +223,7 @@ const fileUploader = {
             delete file.upload;
             file.status = 'done';
             file.progress.current = file.file.size;
+            result.file = file.file;
             return result;
           })
           .catch(async (error) => {


### PR DESCRIPTION
Set request.file to file.file in order for users of the Upload GWC to access files uploaded without needing to download from girder.