### PR TITLE
Bind useful props to dropzone slot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -44,7 +44,10 @@
         </v-btn>
       </v-card-actions>
       <v-col>
-        <slot name="dropzone">
+        <slot
+          name="dropzone"
+          v-bind="{ files, dropzoneMessage, multiple, accept, inputFilesChanged }"
+        >
           <dropzone
             v-if="!files.length"
             :message="dropzoneMessage"


### PR DESCRIPTION
I've got a downstream app that is making use of a custom upload drop zone. Exposing these props to the slot makes things a lot more straightforward; without them I have to hack a few things.