### PR TITLE
Fix duplicate XHRs resulting from asyncComputed

### DIFF
--- a/dkc/views/Browse.vue
+++ b/dkc/views/Browse.vue
@@ -32,8 +32,7 @@ export default {
       return [];
     },
     selected() {
-      // Made an alias for this since I'm not sure if this is the best way to get hold of it
-      return this.$refs.browser.internalValue;
+      return this.$refs.browser.selected;
     },
     termsOfUseHtml() {
       if (this.termsOfUse) {

--- a/dkc/views/Browse.vue
+++ b/dkc/views/Browse.vue
@@ -20,19 +20,17 @@ export default {
     initialized: false,
     showTermsOfUse: false,
     termsOfUse: null,
+    selected: [],
   }),
   computed: {
     detailsList() {
-      if (this.$refs.browser && this.selected.length) {
+      if (this.selected.length) {
         return this.selected;
       }
       if (this.folder) {
         return [this.folder];
       }
       return [];
-    },
-    selected() {
-      return this.$refs.browser.selected;
     },
     termsOfUseHtml() {
       if (this.termsOfUse) {
@@ -190,6 +188,7 @@ export default {
         v-if="initialized"
         ref="browser"
         :folder.sync="folder"
+        v-model="selected"
         :selectable="true"
         :initial-breadcrumbs="fetchedBreadcrumbs"
       />


### PR DESCRIPTION
I noticed that the DataBrowser was sending duplicative XHRs, which I found out was resulting from the asyncComputed getter being fired multiple times even though the values hadn't changed. After fighting with asyncComputed for about 2 hours, I gave up on it and just did it the normal, more procedural way and everything worked fine.

This also fixes an issue of too-aggressively refreshing based on the pagination options watch.