### PR TITLE
Simplify upload worker pool code

### DIFF
--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -245,23 +245,22 @@ const fileUploader = {
       this.errorMessage = null;
       const hookResult = await preUpload();
       this.indeterminate = false;
-      const promiseList = [];
-      // shallow copy into queue
-      const fileQueue = this.files.slice();
+      const results = [];
+      let i = 0;
       const WORKER_POOL_SIZE = 5;
       const workerPool = [...new Array(WORKER_POOL_SIZE)];
       await Promise.all(workerPool.map(async () => {
-        let file = fileQueue.shift();
-        while (file !== undefined) {
+        while (i < this.files.length) {
+          // must increment i before `await`, but after subscript operator
+          // eslint-disable-next-line no-plusplus
+          const file = this.files[i++];
           // eslint-disable-next-line no-await-in-loop
-          promiseList.push(await this.uploadFile({
+          results.push(await this.uploadFile({
             file, hookResult, dest, uploadCls,
           }));
-          file = fileQueue.shift();
         }
       }));
 
-      const results = await Promise.all(promiseList);
       this.indeterminate = true;
       await postUpload({ results });
       this.indeterminate = false;


### PR DESCRIPTION
@subdavis this is a follow-up to #283 to use one of the alternative approaches I mentioned. I tried it using both the generator, and the index variable in closure, and ended up using the simple closure-based one. The generator one felt like overkill for the case of normal iteration over an array.

In addition to that change, I removed the unnecessary `promiseList` -- if I understand correctly, it was redundant since `await`ing the return value of `uploadFile` will already resolve to the result. Please correct me if there's something I'm missing there.