### PR TITLE
Fix overflow style bug in FileUploadList

### DIFF
--- a/src/components/Presentation/FileUploadList.vue
+++ b/src/components/Presentation/FileUploadList.vue
@@ -2,6 +2,7 @@
   <v-list
     v-show="value.length"
     dense="dense"
+    class="files-list"
   >
     <div
       v-for="(file, i) in shownFiles"
@@ -110,6 +111,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.files-list {
+  max-width: 100%;
+}
+
 .file-tile {
   transition:
     width 0.8s ease-in-out 1s,


### PR DESCRIPTION
Noticed this while testing the recent uploader changes. Really long filenames were overflowing the container of the FileUploadList. Before:

<img width="1028" alt="Screen Shot 2020-11-18 at 8 54 10 PM" src="https://user-images.githubusercontent.com/555959/99610791-7a86cd80-29e0-11eb-911a-8bf408e1c157.png">

After:

<img width="979" alt="Screen Shot 2020-11-18 at 8 53 51 PM" src="https://user-images.githubusercontent.com/555959/99610801-7eb2eb00-29e0-11eb-95ff-25563efb7242.png">
