### PR TITLE
Add some flair to the upload drop zone

### DIFF
--- a/src/components/Presentation/Dropzone.vue
+++ b/src/components/Presentation/Dropzone.vue
@@ -6,6 +6,7 @@
     @dragleave="dropzoneClass = null"
     @drop="dropzoneClass = null"
   >
+    <div class="dropzone-overlay" />
     <v-row class="flex-column align-center justify-center fill-height dropzone-message">
       <v-icon size="50px">
         $vuetify.icons.fileUpload
@@ -104,5 +105,49 @@ $img: linear-gradient(
   to {
     background-position: 30px 60px;
   }
+}
+
+$overlayDark: linear-gradient(
+  var(--v-dropzone-lighten3),
+  var(--v-dropzone-lighten3)
+);
+
+$overlayLight: linear-gradient(
+  var(--v-dropzone-darken4),
+  var(--v-dropzone-darken4)
+);
+
+.dropzone-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 7px solid transparent;
+  background:
+    $overlayLight top left,
+    $overlayLight top left,
+    $overlayLight bottom left,
+    $overlayLight bottom left,
+    $overlayLight top right,
+    $overlayLight top right,
+    $overlayLight bottom right,
+    $overlayLight bottom right;
+  background-size: 5px 24px, 24px 5px;
+  background-repeat: no-repeat;
+}
+
+.theme--dark .dropzone-overlay {
+  background:
+    $overlayDark top left,
+    $overlayDark top left,
+    $overlayDark bottom left,
+    $overlayDark bottom left,
+    $overlayDark top right,
+    $overlayDark top right,
+    $overlayDark bottom right,
+    $overlayDark bottom right;
+  background-size: 5px 24px, 24px 5px;
+  background-repeat: no-repeat;
 }
 </style>


### PR DESCRIPTION
I've been staring at the upload component a lot lately in a few different app contexts, and I just felt like it needed a little bit more of a call to action when it was in the waiting for files state. I've seen some other drag and drop upload UIs that show a little frame around the corners of the drop zone, and tried it out here. Let me know what you think.

<img width="920" alt="Screen Shot 2020-11-30 at 4 32 56 PM" src="https://user-images.githubusercontent.com/555959/100668323-c19e8800-3329-11eb-84cb-3670abef2d5a.png">
<img width="912" alt="Screen Shot 2020-11-30 at 4 33 12 PM" src="https://user-images.githubusercontent.com/555959/100668326-c2cfb500-3329-11eb-91aa-1a1af8af58c3.png">
