### PR TITLE
Add transition between upload dropzone and file list

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -48,13 +48,15 @@
           name="dropzone"
           v-bind="{ files, dropzoneMessage, multiple, accept, inputFilesChanged }"
         >
-          <dropzone
-            v-if="!files.length"
-            :message="dropzoneMessage"
-            :multiple="multiple"
-            :accept="accept"
-            @change="inputFilesChanged"
-          />
+          <v-slide-y-reverse-transition hide-on-leave>
+            <dropzone
+              v-if="!files.length"
+              :message="dropzoneMessage"
+              :multiple="multiple"
+              :accept="accept"
+              @change="inputFilesChanged"
+            />
+          </v-slide-y-reverse-transition>
         </slot>
       </v-col>
       <div v-if="errorMessage">
@@ -91,10 +93,13 @@
         v-bind="{ files, setFiles, maxShow }"
         name="files"
       >
-        <file-upload-list
-          v-bind="{ value: files, maxShow }"
-          @input="setFiles"
-        />
+        <v-slide-y-transition hide-on-leave>
+          <file-upload-list
+            v-if="files.length"
+            v-bind="{ value: files, maxShow }"
+            @input="setFiles"
+          />
+        </v-slide-y-transition>
       </slot>
     </v-row>
   </v-card>


### PR DESCRIPTION
This addresses one other qualm I've been having with the upload component, which was that it was visually jarring when switching between the dropzone and the files list. A simple transition makes this a lot better IMO (GIF framerate probably doesn't do it justice).

![uploader](https://user-images.githubusercontent.com/555959/100683610-b017a900-3346-11eb-821d-53f637e8338c.gif)
