### PR TITLE
Remove layout weirdness from Upload component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/src/components/Presentation/Dropzone.vue
+++ b/src/components/Presentation/Dropzone.vue
@@ -7,7 +7,10 @@
     @drop="dropzoneClass = null"
   >
     <div class="dropzone-overlay" />
-    <v-row class="flex-column align-center justify-center fill-height dropzone-message">
+    <v-row
+      no-gutters
+      class="flex-column align-center justify-center fill-height dropzone-message"
+    >
       <v-icon size="50px">
         $vuetify.icons.fileUpload
       </v-icon>

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -43,22 +43,21 @@
           {{ startButtonText }}
         </v-btn>
       </v-card-actions>
-      <v-col>
-        <slot
-          name="dropzone"
-          v-bind="{ files, dropzoneMessage, multiple, accept, inputFilesChanged }"
-        >
-          <v-slide-y-reverse-transition hide-on-leave>
+      <v-slide-y-reverse-transition hide-on-leave>
+        <v-col v-if="!files.length">
+          <slot
+            name="dropzone"
+            v-bind="{ files, dropzoneMessage, multiple, accept, inputFilesChanged }"
+          >
             <dropzone
-              v-if="!files.length"
               :message="dropzoneMessage"
               :multiple="multiple"
               :accept="accept"
               @change="inputFilesChanged"
             />
-          </v-slide-y-reverse-transition>
-        </slot>
-      </v-col>
+          </slot>
+        </v-col>
+      </v-slide-y-reverse-transition>
       <div v-if="errorMessage">
         <v-alert
           :value="true"

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -4,7 +4,7 @@
     flat="flat"
   >
     <v-row
-      class="flex-column fill-height"
+      class="flex-column flex-nowrap fill-height"
       no-gutters="no-gutters"
     >
       <slot name="header">
@@ -96,6 +96,7 @@
           <file-upload-list
             v-if="files.length"
             v-bind="{ value: files, maxShow }"
+            :style="{overflow: 'scroll'}"
             @input="setFiles"
           />
         </v-slide-y-transition>


### PR DESCRIPTION
I ran into an issue using this downstream, where trying to have a larger height component caused a bunch of blank space to appear between the actions and the file list. This was due to an empty `v-col` that was apparently set to grow.

I can't figure out why the `v-row` or `v-col` were even present before. Removing them doesn't break anything that I can see currently.

Screenshot of problem:

<img width="962" alt="Screen Shot 2020-12-03 at 3 13 39 PM" src="https://user-images.githubusercontent.com/555959/101087027-a88f1480-357f-11eb-8dde-b0f84af5779d.png">
