### PR TITLE
Fix CSS tree shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ yarn lint:style
 yarn test:unit
 ```
 
+> **Note**: sideEffects config for tree shaking is [informed by this issue](https://github.com/vuejs/vue-loader/issues/1435)
+
 ### Use an external Girder API
 
 To build the demo app against an external Girder API, set the

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "/vue.config.js"
   ],
   "sideEffects": [
+    "*.vue",
     "*.css"
   ],
   "dependencies": {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import '@mdi/font/css/materialdesignicons.min.css';
 
 import GirderAccessControl from './AccessControl.vue';
 import GirderBreadcrumb from './Breadcrumb.vue';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import '@mdi/font/css/materialdesignicons.min.css';
 import VueAsyncComputed from 'vue-async-computed';
 import Vuetify from 'vuetify/lib';
 


### PR DESCRIPTION
#293 broke CSS.  See gwc.girder.org - didn't notice locally because this optimization is disabled in dev mode.

This fix is related to https://github.com/vuejs/vue-loader/issues/1435, which is described as "undocumented". /shrug