### PR TITLE
Better document vue/vuetify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,33 @@ It works with [data.kitware.com](https://data.kitware.com/).
 
 ## Usage Quickstart
 
+**This library only supports Vue 2.**
+
 ### Installation
 
+[Vue CLI](https://cli.vuejs.org/) is required for building applications with Girder web components.  You will also need to install [Vue CLI Plugin Vuetify](https://next.vuetifyjs.com/en/getting-started/installation/#vue-cli-install).
+
+First, install Vuetify if you aren't already using it.
+
+``` bash
+vue add vuetify
+```
+
+For new projects, the `default` preset is good.  For established projects, choose `advanced` and reject pre-made templates for a less invasive install.  All other options are up to you.
+
+> **Note** the cli plugin install may modify package.json, vue.config.js, index.html, and several others.  Mostly, it just reorders your existing configuration, but be sure to review the changes carefully.
+
 ```bash
-npm install @girder/components
-# or
+# Install GWC
 yarn add @girder/components
-```
-
-[VueCLI](https://cli.vuejs.org/) is required for building applications with Girder web components.
-However, a few additional packages must still be manually installed:
-
-```bash
-npm install -D sass sass-loader@^7.3.1 vue-cli-plugin-vuetify vuetify-loader
 # or
-yarn add -D sass sass-loader@^7.3.1 vue-cli-plugin-vuetify vuetify-loader
+npm install @girder/components
+
+# Install additional dev dependencies
+yarn add -D sass sass-loader@^7.3.1
 ```
 
-> **Note:** If you are building with custom webpack (without vue-cli-service),
-> you should follow Vuetify's [Webpack install instructions](https://vuetifyjs.com/en/getting-started/quick-start/#webpack-install)
+> **Note:** If you are building with custom webpack (without vue-cli-service), you should follow Vuetify's [Webpack install instructions](https://vuetifyjs.com/en/getting-started/quick-start/#webpack-install)
 
 ### Initialization
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   "sideEffects": [
     "*.css"
   ],
-  "peerDependencies": {
-    "vue": "^2.6.12",
-    "vuetify": "^2.3.1"
-  },
   "dependencies": {
     "@mdi/font": "^5.3.45",
     "axios": "^0.19.2",
@@ -55,7 +51,9 @@
     "stylelint-config-standard": "^20.0.0",
     "vue-cli-plugin-vuetify": "~2.0.5",
     "vue-template-compiler": "^2.6.12",
-    "vuetify-loader": "^1.5.0"
+    "vue": "^2.6.12",
+    "vuetify-loader": "^1.5.0",
+    "vuetify": "^2.3.1"
   },
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "sideEffects": [
     "*.css"
   ],
+  "peerDependencies": {
+    "vue": "^2.6.12",
+    "vuetify": "^2.3.1"
+  },
   "dependencies": {
     "@mdi/font": "^5.3.45",
     "axios": "^0.19.2",
@@ -29,9 +33,7 @@
     "markdown-it": "^11.0.0",
     "moment": "^2.27.0",
     "qs": "^6.9.4",
-    "vue": "^2.6.12",
-    "vue-async-computed": "^3.4.1",
-    "vuetify": "^2.3.1"
+    "vue-async-computed": "^3.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "markdown-it": "^11.0.0",
     "moment": "^2.27.0",
     "qs": "^6.9.4",
-    "vue-async-computed": "^3.4.1"
+    "vue": "^2.6.12",
+    "vue-async-computed": "^3.4.1",
+    "vuetify": "^2.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",
@@ -51,9 +53,7 @@
     "stylelint-config-standard": "^20.0.0",
     "vue-cli-plugin-vuetify": "~2.0.5",
     "vue-template-compiler": "^2.6.12",
-    "vue": "^2.6.12",
-    "vuetify-loader": "^1.5.0",
-    "vuetify": "^2.3.1"
+    "vuetify-loader": "^1.5.0"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
Made both Vue and Vuetify peer dependencies.

Had to change the install guide to explicitly install vuetify, and realized I was just replicating Vuetify docs inline.

So I switched to recommending `vue add vuetify` as the install mechanism, since it does quite a lot of work that a user would otherwise have to guess from looking at the GWC package json and vue.config.js

This way, for the most common case of "fresh project", you get a more first-class vuetify experience rather than trying to replicate our config by hand.