### PR TITLE
version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",


### PR DESCRIPTION
deploy changes from #293 

# Migration Guide

* Components explicitly renamed to `Girder*`.  No need to rename on import
* All imports provided from project index.  No need to provide path within library.
* registerComponents helper function
* typescript type definitions

## Imports

**Old**

``` js
// Plugin, RestClient, Vuetify
import Girder, { RestClient, vuetify } from '@girder/components/src';
// Components
import { Authentication as GirderAuthentication } from '@girder/components/src/components'
```

**New**

``` js
// Plugin, RestClient, Vuetify
import Girder, { RestClient, vuetify } from '@girder/components';
// Components
import { GirderAuthentication } from '@girder/components';
```

## registerComponents

Adds a simple helper function to register the main components globally, so you can do this:

``` js
// main.js
import { registerComponents } from '@girder/components';
registerComponents();

// App.vue
// No import necessary!
<template>
  <girder-file-manager />
</template>
```