### PR TITLE
Row slot

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -214,7 +214,15 @@
                 :upload-multiple="uploadMultiple"
                 :upload-enabled="uploadEnabled"
                 @dragend="dragend"
-              />
+              >
+                <!--
+                  Example usage of row item customization.
+                  This template can be omitted if no changes are needed.
+                -->
+                <template #row="props">
+                  <i>{{ props.item.name }}</i>
+                </template>
+              </girder-file-manager>
               <v-card
                 v-if="dragEnabled"
                 class="mt-4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girder/components",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "scripts": {
     "serve": "vue-cli-service serve demo/main.js",
     "build": "vue-cli-service build --target lib --name girder src/index.js",

--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -369,10 +369,11 @@ export default {
           </th>
         </tr>
       </thead>
-    </template><template #row-widget="props">
+    </template>
+    <template #row="props">
       <slot
         v-bind="props"
-        name="row-widget"
+        name="row"
       />
     </template>
   </girder-data-table>

--- a/src/components/Presentation/DataTable.vue
+++ b/src/components/Presentation/DataTable.vue
@@ -138,11 +138,12 @@ export default {
               :color="props.isSelected ? 'accent' : ''"
               class="pr-2"
             >{{ $vuetify.icons.values[props.item.icon] }}</v-icon>
-            {{ props.item.name }}
             <slot
               v-bind="props"
-              name="row-widget"
-            />
+              name="row"
+            >
+              {{ props.item.name }}
+            </slot>
           </span>
         </td>
         <td class="text-right nobreak">

--- a/src/components/snippets/FileManager.vue
+++ b/src/components/snippets/FileManager.vue
@@ -281,10 +281,11 @@ export default Vue.extend({
             @dismiss="newFolderDialog = false"
           />
         </v-dialog>
-      </template><template #row-widget="props">
+      </template>
+      <template #row="props">
         <slot
           v-bind="props"
-          name="row-widget"
+          name="row"
         />
       </template>
     </girder-data-browser>


### PR DESCRIPTION
## Changes

The old slot was too narrowly scoped.  Rather than maintain backward compatibility and have 2 named slots in exactly the same place, this introduces a breaking change:

* Remove `row-widget` slot in DataBrowser, DataTable, FileManager
* Replace with `row` slot that can be used to customize the entire presentation of the item/folder row.

## Release

Release 3.2.0

## Example Usage

Trivial example to make the text italicized.

``` html
<girder-file-manager>
    <template #row="props">
      <i>{{ props.item.name }}</i>
     </template>
</girder-file-manager>
```