### PR TITLE
ci: fix gwc.girder.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Girder Components Demo</title>
   </head>
   <body>
+    <noscript>
+      <strong>We're sorry but girder-lib doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
     <div id="app"></div>
     <script type="module" src="./demo/main.js"></script>
   </body>

--- a/vite.config.js
+++ b/vite.config.js
@@ -50,9 +50,6 @@ export default defineConfig({
     ? {
         outDir: '_site',
         emptyOutDir: true,
-        rollupOptions: {
-          input: 'demo/main.js',
-        },
       }
     : {
     lib: {


### PR DESCRIPTION
Contrary to Webpack, Vite does not process a .js file as input but HTML files. By default, Vite considers index.html located at the root of the project.