### PR TITLE
Fix upload progress bar broken in Vue 3 (v4.0.0)

### DIFF
--- a/src/components/Upload/Upload.vue
+++ b/src/components/Upload/Upload.vue
@@ -61,10 +61,10 @@ export default {
     );
 
     const statusMessage = computed(() => {
-      if (uploading) {
-        return `${formatSize(totalProgress)} / ${formatSize(totalSize)} (${formatSize(totalProgressPercent)}%)`;
+      if (uploading.value) {
+        return `${formatSize(totalProgress.value)} / ${formatSize(totalSize.value)} (${formatSize(totalProgressPercent.value)}%)`;
       }
-      return `${files.length} selected (${formatSize(totalSize)} total)`;
+      return `${files.value.length} selected (${formatSize(totalSize.value)} total)`;
     });
 
     function startUpload() {
@@ -108,7 +108,7 @@ export default {
         </div>
         <v-progress-linear
           v-if="uploading"
-          :value="totalProgressPercent"
+          :model-value="totalProgressPercent"
           :indeterminate="indeterminate"
           height="20"
         />

--- a/src/components/Upload/Upload.vue
+++ b/src/components/Upload/Upload.vue
@@ -62,7 +62,7 @@ export default {
 
     const statusMessage = computed(() => {
       if (uploading.value) {
-        return `${formatSize(totalProgress.value)} / ${formatSize(totalSize.value)} (${formatSize(totalProgressPercent.value)}%)`;
+        return `${formatSize(totalProgress.value)} / ${formatSize(totalSize.value)} (${Math.round(totalProgressPercent.value)}%)`;
       }
       return `${files.value.length} selected (${formatSize(totalSize.value)} total)`;
     });

--- a/src/composables/upload.js
+++ b/src/composables/upload.js
@@ -45,7 +45,7 @@ export default function usefileUploader({ girderRest, onFilesChanged, onError, o
     let chain = Promise.resolve();
     if (file.status === 'done') {return chain.then(() => file.result);}
 
-    const progress = (event) => { file.progress = event; };
+    const progress = (event) => { Object.assign(file.progress, event); };
     file.status = 'uploading';
     file.progress.indeterminate = true;
 


### PR DESCRIPTION
## Summary

Fixes the upload progress header always displaying "0 B / 0 B (0 B%)" in v4.0.0. Three Vue 2 → Vue 3 migration issues:

- **Missing `.value`** on refs in `statusMessage` computed (`Upload.vue`): `uploading`, `totalProgress`, `totalSize`, `totalProgressPercent`, and `files` are refs from `usefileUploader` but were accessed without `.value` in `setup()`. A ref object is always truthy, and `formatSize(refObject)` returns "0 B".
- **Reactive proxy replacement** in progress callback (`upload.js`): `file.progress = event` replaces the reactive proxy with a plain object, breaking computed dependency tracking. Changed to `Object.assign(file.progress, event)`.
- **Vuetify 3 prop name** (`Upload.vue`): `:value` → `:model-value` on `v-progress-linear`.

Fixes #361

## Test plan

- [x] Upload a file using GirderUpload component
- [x] Verify progress header shows actual bytes transferred (e.g., "37.30 MB / 671.80 MB (5%)")
- [x] Verify progress bar fills during upload
- [x] Verify per-file progress still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)