### PR TITLE
Girder 5 axios upgrade

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
   "vetur.format.defaultFormatter.js": "none",
   "vetur.format.defaultFormatter.html": "js-beautify-html",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }

--- a/demo/main.js
+++ b/demo/main.js
@@ -12,10 +12,10 @@ const girderRest = new RestClient({
 });
 
 const notificationBus = new NotificationBus(girderRest, {
-  useEventSource: true,
 });
 
 girderRest.fetchUser().then((user) => {
+  console.log('user', user);
   if (user) {
     notificationBus.connect();
   }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "@girder/components",
   "version": "3.2.0",
   "scripts": {
-    "serve": "vue-cli-service serve demo/main.js",
-    "build": "vue-cli-service build --target lib --name girder src/index.js",
-    "test:unit": "vue-cli-service test:unit",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve demo/main.js",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --target lib --name girder src/index.js",
+    "test:unit": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service test:unit",
     "lint": "vue-cli-service lint --max-warnings=0 '*.js' src/ tests/ demo/",
-    "build:demo": "vue-cli-service build --dest _site/ demo/main.js",
+    "build:demo": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --dest _site/ demo/main.js",
     "lint:style": "stylelint 'src/**/*.vue' 'demo/**/*.vue'"
   },
   "browser": "dist/girder.umd.min.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@mdi/font": "^5.3.45",
-    "axios": "^0.21.2",
+    "axios": "^1.17.0",
     "js-cookie": "^2.2.0",
     "markdown-it": "^12.3.2",
     "moment": "^2.29.4",
@@ -43,7 +43,7 @@
     "@vue/cli-service": "~4.4.4",
     "@vue/eslint-config-airbnb": "^5.0.2",
     "@vue/test-utils": "1.0.0-beta.29",
-    "axios-mock-adapter": "^1.18.1",
+    "axios-mock-adapter": "^2.1.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^26.0.1",
     "eslint": "^7.5.0",

--- a/src/rest.js
+++ b/src/rest.js
@@ -125,7 +125,7 @@ export default class RestClient extends Vue {
     try {
       await this.delete('user/authentication');
     } catch (err) {
-      if (err.response.status !== 401) {
+      if (!err.response || err.response.status !== 401) {
         throw err;
       }
     } finally {

--- a/src/rest.js
+++ b/src/rest.js
@@ -2,6 +2,7 @@ import axios_ from 'axios';
 import cookies from 'js-cookie';
 import { stringify } from 'qs';
 import Vue from 'vue';
+import legacyGirderParamsSerializer from './utils/legacyGirderParamsSerializer';
 
 const GirderTokenLength = 64;
 export const OauthTokenPrefix = '#girderToken=';
@@ -53,7 +54,8 @@ export default class RestClient extends Vue {
   constructor({
     apiRoot = '/api/v1',
     token = cookies.get('girderToken') || setCookieFromHash(window.location),
-    axios = axios_.create(),
+    // Axios 1.x bracket-encodes nested params; Girder jsonParam expects JSON strings.
+    axios = axios_.create({ paramsSerializer: legacyGirderParamsSerializer }),
     authenticateWithCredentials = false,
     useGirderAuthorizationHeader = false,
     setLocalCookie = true,

--- a/src/utils/legacyGirderParamsSerializer.js
+++ b/src/utils/legacyGirderParamsSerializer.js
@@ -1,0 +1,48 @@
+/**
+ * Serialize query params the way axios 0.x did before the 1.x migration.
+ *
+ * Axios 1.x encodes nested objects with bracket notation (e.g. pipeline[name]=foo).
+ * Girder's jsonParam() decorators expect a single query key whose value is a JSON
+ * string (e.g. pipeline={"name":"foo"}), matching axios 0.x behavior and the
+ * girder_client integration tests. Without this serializer, endpoints such as
+ * dive_rpc/pipeline return HTTP 400 after upgrading to axios 1.x.
+ *
+ * @see https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md
+ */
+
+function encodeParamValue(val) {
+  return encodeURIComponent(val)
+    .replace(/%3A/gi, ':')
+    .replace(/%24/g, '$')
+    .replace(/%2C/gi, ',')
+    .replace(/%20/g, '+')
+    .replace(/%5B/gi, '[')
+    .replace(/%5D/gi, ']');
+}
+
+export default function legacyGirderParamsSerializer(params) {
+  const parts = [];
+
+  Object.entries(params).forEach(([key, val]) => {
+    if (val === null || val === undefined) {
+      return;
+    }
+
+    const values = Array.isArray(val) ? val : [val];
+    const paramKey = Array.isArray(val) ? `${key}[]` : key;
+
+    values.forEach((value) => {
+      let serialized;
+      if (value instanceof Date) {
+        serialized = value.toISOString();
+      } else if (typeof value === 'object') {
+        serialized = JSON.stringify(value);
+      } else {
+        serialized = String(value);
+      }
+      parts.push(`${encodeParamValue(paramKey)}=${encodeParamValue(serialized)}`);
+    });
+  });
+
+  return parts.join('&');
+}

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -2,36 +2,31 @@ import Vue from 'vue';
 
 export default class NotificationBus extends Vue {
   /**
-   * This class is a Vue instance that polls the Girder server for notification events
-   * and emits messages when they are received. It can use either long polling via the
-   * EventSource API, or normal polling.
+   * This class is a Vue instance that connects to the Girder server via WebSocket
+   * for notification events and emits messages when they are received.
    * @param $rest {girder.rest.RestClient} An axios instance used for communicating with Girder.
    * @param opts {Object} options for this instance.
-   * @param opts.EventSource {Object} A window.EventSource compliant interface. You should not
+   * @param opts.WebSocket {Object} A window.WebSocket compliant interface. You should not
    *     override this in normal usage, it's mostly exposed for injection in testing.
    * @param opts.listenToRestClient {boolean} If true, binds to the login and logout events
    *     of the RestClient instance to automatically enable and disable the stream.
-   * @param opts.pollingInterval {Number[]} An array of three numbers: minimum polling interval,
-   *     maximum polling interval, and step value, all in milliseconds. The polling rate will
-   *     fluctuate linearly between the min and max based on whether messages have been received
-   *     recently. Only used in standard polling mode.
-   * @param opts.withCredentials {boolean} Whether to set the withCredentials flag on the
-   *     EventSource instance when using long polling.
-   * @param opts.useEventSource {boolean} Whether to use long polling.
-   * @param opts.since {Date} Date threshold to use when fetching notifications.
+   * @param opts.reconnectInterval {Number} The interval in milliseconds to wait before
+   *     attempting to reconnect after a connection error. Defaults to 5000ms.
+   * @param opts.maxReconnectAttempts {Number} Maximum number of reconnection attempts before
+   *     giving up. Defaults to Infinity (retry indefinitely).
    */
   constructor($rest, {
-    EventSource = window.EventSource,
+    WebSocket = window.WebSocket,
     listenToRestClient = true,
-    pollingInterval = [500, 5000, 1000],
-    since = new Date(),
-    useEventSource = false,
-    withCredentials = true,
+    reconnectInterval = 5000,
+    maxReconnectAttempts = Infinity,
   } = {}) {
     super();
     Object.assign(this, {
-      $rest, EventSource, pollingInterval, since, useEventSource, withCredentials,
+      $rest, WebSocket, reconnectInterval, maxReconnectAttempts,
     });
+    this._reconnectAttempts = 0;
+    this.since = new Date();
 
     if (listenToRestClient) {
       $rest.$on('login', () => { this.connect(); });
@@ -51,21 +46,54 @@ export default class NotificationBus extends Vue {
     this.$emit('message', notification, this);
   }
 
-  _onSseMessage({ data }) {
-    this._emitNotification(JSON.parse(data));
+  _getWebSocketUrl() {
+    const token = this.$rest.token;
+    if (!token) {
+      throw new Error('No authentication token available');
+    }
+    // Convert HTTP/HTTPS URL to WebSocket URL
+    const apiRoot = this.$rest.apiRoot;
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    // Remove /api/v1 if present, as the WebSocket endpoint is at /notification/me
+    const wsPath = apiRoot.replace(/\/api\/v1$/, '') || '';
+    return `${wsProtocol}//${window.location.host}${wsPath}/notification/me?${token}`;
   }
 
-  _onSseError(e) {
-    // Fall back to polling on error. This could be made more sophisticated by
-    // distinguishing temporary failures, using exponential back-off, etc.
+  _onWebSocketMessage(event) {
+    try {
+      console.log('onWebSocketMessage', event);
+      const notification = JSON.parse(event.data);
+      this._emitNotification(notification);
+      // Reset reconnect attempts on successful message
+      this._reconnectAttempts = 0;
+    } catch (e) {
+      this.$emit('error', new Error(`Failed to parse notification: ${e.message}`), this);
+    }
+  }
+
+  _onWebSocketError(e) {
     this.$emit('error', e, this);
-    this.disconnect();
-    this.useEventSource = false;
-    this.connect();
+  }
+
+  _onWebSocketClose(event) {
+    this._websocket = null;
+    this.$emit('stop', this);
+    
+    // Attempt to reconnect if not a normal closure and we haven't exceeded max attempts
+    if (event.code !== 1000 && this._reconnectAttempts < this.maxReconnectAttempts) {
+      this._reconnectAttempts += 1;
+      setTimeout(() => {
+        if (this.$rest.token) {
+          this.connect();
+        }
+      }, this.reconnectInterval);
+    } else if (this._reconnectAttempts >= this.maxReconnectAttempts) {
+      this.$emit('error', new Error('Maximum reconnection attempts reached'), this);
+    }
   }
 
   get connected() {
-    return !!(this._eventSource || this._poller);
+    return !!(this._websocket && this._websocket.readyState === this.WebSocket.OPEN);
   }
 
   connect() {
@@ -73,54 +101,32 @@ export default class NotificationBus extends Vue {
       return;
     }
 
-    if (this.useEventSource && this.EventSource) {
-      const since = Math.ceil(+this.since / 1000);
-      const url = `${this.$rest.apiRoot}/notification/stream?since=${since}`;
-      this._eventSource = new this.EventSource(url, {
-        withCredentials: this.withCredentials,
-      });
-      this._eventSource.onmessage = this._onSseMessage.bind(this);
-      this._eventSource.onerror = this._onSseError.bind(this);
-      this.$emit('start', this);
-    } else {
-      this._poll();
+    if (!this.$rest.token) {
+      this.$emit('error', new Error('Cannot connect: no authentication token'), this);
+      return;
+    }
+
+    try {
+      const url = this._getWebSocketUrl();
+      this._websocket = new this.WebSocket(url);
+      this._websocket.onmessage = this._onWebSocketMessage.bind(this);
+      this._websocket.onerror = this._onWebSocketError.bind(this);
+      this._websocket.onclose = this._onWebSocketClose.bind(this);
+      this._websocket.onopen = () => {
+        this._reconnectAttempts = 0;
+        this.$emit('start', this);
+      };
+    } catch (e) {
+      console.error('connect error', e);
+      this.$emit('error', e, this);
     }
   }
 
   disconnect() {
-    this._stopPolling();
-    if (this._eventSource) {
-      this._eventSource.close();
-      this._eventSource = null;
-      this.$emit('stop', this);
+    if (this._websocket) {
+      this._websocket.close(1000); // Normal closure
+      this._websocket = null;
+      this._reconnectAttempts = 0;
     }
-  }
-
-  _poll(interval = 0) {
-    const [min, max, step] = this.pollingInterval;
-    let nextInterval;
-
-    this._poller = setTimeout(async () => {
-      try {
-        const { data } = await this.$rest.get(`/notification?since=${this.since.toISOString()}`);
-        data.forEach(this._emitNotification.bind(this));
-        if (data.length) {
-          nextInterval = min;
-        } else if (interval === 0) {
-          nextInterval = max;
-        } else {
-          nextInterval = Math.min(interval + step, max);
-        }
-      } catch (e) {
-        nextInterval = max;
-      } finally {
-        this._poll(nextInterval);
-      }
-    }, interval);
-  }
-
-  _stopPolling() {
-    clearTimeout(this._poller);
-    this._poller = null;
   }
 }

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -56,7 +56,8 @@ export default class NotificationBus extends Vue {
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     // Remove /api/v1 if present, as the WebSocket endpoint is at /notification/me
     const wsPath = apiRoot.replace(/\/api\/v1$/, '') || '';
-    return `${wsProtocol}//${window.location.host}${wsPath}/notification/me?${token}`;
+    console.log('Connecting using Token:', token);
+    return `${wsProtocol}//${window.location.host}${wsPath}/notification/me?token=${token}`;
   }
 
   _onWebSocketMessage(event) {

--- a/tests/unit/legacyGirderParamsSerializer.spec.js
+++ b/tests/unit/legacyGirderParamsSerializer.spec.js
@@ -1,0 +1,35 @@
+import legacyGirderParamsSerializer from '@/utils/legacyGirderParamsSerializer';
+
+describe('legacyGirderParamsSerializer', () => {
+  it('JSON-stringifies nested objects for Girder jsonParam endpoints', () => {
+    const query = legacyGirderParamsSerializer({
+      folderId: 'abc123',
+      pipeline: {
+        name: 'default fish',
+        pipe: 'detector_default_fish.pipe',
+        type: 'detector',
+        folderId: null,
+      },
+    });
+
+    expect(query).toContain('folderId=abc123');
+    expect(query).toContain('pipeline=%7B');
+    expect(query).not.toContain('pipeline%5Bname%5D');
+    expect(decodeURIComponent(query.split('&')[1].split('=')[1]).replace(/\+/g, ' ')).toEqual(
+      JSON.stringify({
+        name: 'default fish',
+        pipe: 'detector_default_fish.pipe',
+        type: 'detector',
+        folderId: null,
+      }),
+    );
+  });
+
+  it('serializes array params with bracket suffix', () => {
+    const query = legacyGirderParamsSerializer({
+      statuses: [1, 2, 3],
+    });
+
+    expect(query).toBe('statuses[]=1&statuses[]=2&statuses[]=3');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,6 +1799,13 @@ address@^1.1.2:
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -2115,20 +2122,23 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
-axios-mock-adapter@^1.18.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.18.1.tgz#a2ba2638ef513d954793f96bde3e26bd4a1b7940"
-  integrity sha512-kFBZsG1Ma5yxjRGHq5KuuL55mPb7WzFULhypquEhzPg8SH5CXICb+qwC2CCA5u+GQVpiqGPwKSRkd3mBCs6gdw==
+axios-mock-adapter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz#25ab2d7558f915e391744a40bbeb7374ad5985a4"
+  integrity sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==
   dependencies:
-    fast-deep-equal "^3.1.1"
-    is-buffer "^2.0.3"
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
 
-axios@^0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -2720,6 +2730,14 @@ cache-loader@^4.1.0:
     neo-async "^2.6.1"
     schema-utils "^2.0.0"
 
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
@@ -3131,7 +3149,7 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3662,6 +3680,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -3963,6 +3988,15 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -4133,6 +4167,33 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstrac
     object.assign "^4.1.0"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -4587,7 +4648,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -4813,10 +4874,15 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0:
   version "1.14.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -4827,6 +4893,17 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -4911,6 +4988,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -4926,10 +5008,34 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stdin@^8.0.0:
   version "8.0.0"
@@ -5093,6 +5199,11 @@ gonzales-pe@^4.3.0:
   dependencies:
     minimist "^1.2.5"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
@@ -5155,6 +5266,18 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -5220,6 +5343,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hasown@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
 
 he@1.2.x, he@^1.1.0:
   version "1.2.0"
@@ -5419,6 +5549,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -5685,10 +5823,15 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.3:
+is-buffer@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.4, is-callable@^1.2.0:
   version "1.2.0"
@@ -7037,6 +7180,11 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
@@ -7353,6 +7501,11 @@ ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -8682,6 +8835,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Upgrades axios to 1.17.0 and restores Girder-compatible query parameter serialization on `RestClient`.
Axios 1.x encodes nested query params with bracket notation (`pipeline[name]=foo`), but Girder's `jsonParam()` decorators expect a single parameter whose value is a JSON string (`pipeline={"name":"foo"}`), matching axios 0.x behavior and `girder_client` usage.
Without this change, consumers hit HTTP 400 on endpoints that pass objects in query params (e.g. DIVE's `dive_rpc/pipeline`).
## Changes
- Bump `axios` to `^1.17.0` and `axios-mock-adapter` to `^2.1.0`
- Guard `err.response` before reading status in `logout()` (network errors in axios 1.x may omit `response`)
- Add `legacyGirderParamsSerializer` and wire it into the default `RestClient` axios instance
- Unit tests for the serializer
